### PR TITLE
Chore: Stricter linting

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint",
+    "lint": "eslint --max-warnings 0",
     "format": "prettier --write src/",
     "format:check": "prettier --check src/"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,7 +8,7 @@
     "dev": "vite build --watch",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "lint": "eslint",
+    "lint": "eslint --max-warnings 0",
     "format": "prettier --write src/",
     "format:check": "prettier --check src/"
   },


### PR DESCRIPTION
Disallows any eslint warnings in the CI/CD pipeline.