### PR TITLE
Better code showcase in storybook

### DIFF
--- a/packages/ui/.storybook/preview.tsx
+++ b/packages/ui/.storybook/preview.tsx
@@ -35,7 +35,7 @@ export default {
       page: DocsTemplate,
       source: {
         excludeDecorators: true,
-        type: "code",
+        type: "auto",
         dark: true,
       },
     },


### PR DESCRIPTION
Changed `docs.source.type` to `auto` se have better code showcase.