### PR TITLE
chore: add packages to ignoredBuiltDependencies

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,9 @@ packages:
   - packages/*
 
 ignoredBuiltDependencies:
+  - cpu-features
   - esbuild
+  - protobufjs
   - sharp
+  - ssh2
   - unrs-resolver


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of what this PR does -->

Adds some packages to `pnpm-workspace.yaml` `ignoredBuildDependencies`. Should silence the pnpm warning.

### Type of Change

<!-- Please keep the relevant option and delete the rest. -->

- **Chore**

### Checklist

<!-- Check all that apply -->

- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published