### PR TITLE
fix: UI build error

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.es.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "vite build",
+    "build": "tsc --noEmit && vite build",
     "dev": "vite build --watch",
     "test": "vitest --project=storybook --coverage",
     "storybook": "storybook dev -p 6006",

--- a/packages/ui/src/components/Controls/Controls.stories.tsx
+++ b/packages/ui/src/components/Controls/Controls.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import React from "react";
 import { Controls } from "./Controls";
-import { expect, fn, userEvent, within } from "storybook/test";
+import { clearAllMocks, expect, fn, userEvent, within } from "storybook/test";
 import { colorNames } from "@/styles/colorType";
 
 const meta: Meta<typeof Controls> = {
@@ -133,7 +133,7 @@ export const Disabled: Story = {
     });
 
     await step("Disabled options do not trigger onChange", async () => {
-      args.onChange?.mockClear();
+      clearAllMocks();
 
       const disable = canvas.getByRole("radio", { name: /disable/i });
       await userEvent.click(disable);
@@ -141,7 +141,7 @@ export const Disabled: Story = {
     });
 
     await step("Disabled options ignore keyboard", async () => {
-      args.onChange?.mockClear();
+      clearAllMocks();
 
       const enable = canvas.getByRole("radio", { name: /enable/i });
       enable.focus();
@@ -232,7 +232,7 @@ export const KeyboardInteraction: Story = {
     });
 
     await step("Unhandled key does nothing", async () => {
-      args.onChange?.mockClear();
+      clearAllMocks();
 
       const enable = canvas.getByRole("radio", { name: /enable/i });
       enable.focus();

--- a/packages/ui/src/components/Controls/Controls.tsx
+++ b/packages/ui/src/components/Controls/Controls.tsx
@@ -174,7 +174,9 @@ const ControlsInner = <T extends string>(
           <button
             key={opt.value}
             id={optionId}
-            ref={el => (buttonRefs.current[index] = el)}
+            ref={el => {
+              buttonRefs.current[index] = el;
+            }}
             type="button"
             className={cl(styles.item, active && styles.active)}
             disabled={disabled ? true : undefined}

--- a/packages/ui/src/components/DropdownControls/DropdownControls.tsx
+++ b/packages/ui/src/components/DropdownControls/DropdownControls.tsx
@@ -86,7 +86,7 @@ const DropdownControlsInner = <T extends string>(
         onChange={handleChange}
         getOptionProps={(opt, index) => ({
           id: `${optionIdBase}-${index}`,
-          "aria-controls": opt.content ? contentId : undefined,
+          "aria-controls": opt.value ? contentId : undefined,
         })}
         className={cl(controlsStyles.embedded, expanded && controlsStyles.inactiveOption)}
       />

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -12,7 +12,6 @@
     "moduleResolution": "Bundler",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"],


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of what this PR does -->

The `ui` package had typescript errors which made the build fail. 

This managed to make it to main because vite does not return an error code when encountering typescript errors, so the CI/CD pipeline still passed. `tsc --noEmit` has been added to the `ui` build script to avoid this in the future.

### Type of Change

<!-- Please keep the relevant option and delete the rest. -->

- **Bug fix** (non-breaking change which fixes an issue)

### Changes Made

<!-- List the specific changes made in this PR -->

- Fixed typescript type errors in `ui` components.
- Added `tsc --noEmit` to `ui` build script to cause CI/CD pipeline to fail when typescript errors are present.

### Checklist

<!-- Check all that apply -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
