### PR TITLE
Fixed `onClick` for sidebar when closed

### DIFF
--- a/packages/ui/src/components/Sidebar/SidebarItem.tsx
+++ b/packages/ui/src/components/Sidebar/SidebarItem.tsx
@@ -2,7 +2,7 @@ import { HTMLAttributes } from "react";
 import styles from "./Sidebar.module.css";
 import { useSidebar } from "./SidebarContext";
 
-export interface SidebarItemProps extends HTMLAttributes<HTMLDivElement> {
+export interface SidebarItemProps extends HTMLAttributes<HTMLButtonElement> {
   /**
    * The icon to the left of the (optional) text for the links to other pages
    * in the sidebar. This icon is the only thing shown for the link to the page
@@ -18,13 +18,9 @@ export const SidebarItem = ({ children, icon, ...rest }: SidebarItemProps) => {
   const { open } = useSidebar();
 
   return (
-    <button className={styles.sidebarItem}>
+    <button className={styles.sidebarItem} {...rest}>
       {icon}
-      {open && (
-        <span className={styles.itemTitle} {...rest}>
-          {children}
-        </span>
-      )}
+      {open && <span className={styles.itemTitle}>{children}</span>}
     </button>
   );
 };


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of what this PR does -->
This PR fixes `onClick` for the sidebar. The `onClick` option was wrongly on the `span` and not on the `button` element.

### Type of Change

<!-- Please keep the relevant option and delete the rest. -->

- **Bug fix** (non-breaking change which fixes an issue)

### Related Issues

<!-- Link related issues using #issue_number or "Fixes #issue_number" to auto-close -->

None

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
This fix was made so the sidebar works even when it is colapsed.

### Changes Made

<!-- List the specific changes made in this PR -->

- Moved `{...rest}` to button element instead of span
- Changed `HTMLDivElement` to `HTMLButtonElement`

### How Has This Been Tested?

<!-- Describe the testing you've performed -->
With the tests already existing in the project

**Test Configuration**:

- **OS**: Windows 11
- **Version**: 0.1.0
- **Browser** (if applicable): Firefox

### Checklist

<!-- Check all that apply -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities