### PR TITLE
Fix: Make `typescript-result` an external package in next.config.ts

### DIFF
--- a/apps/website/next.config.ts
+++ b/apps/website/next.config.ts
@@ -5,7 +5,7 @@ const nextConfig: NextConfig = {
   /* config options here */
   reactCompiler: true,
   transpilePackages: ["ui", "file-storage"],
-  serverExternalPackages: ["better-sqlite3"],
+  serverExternalPackages: ["better-sqlite3", "typescript-result"],
   outputFileTracingIncludes: {
     "/": ["drizzle/**/*"],
   },


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of what this PR does -->

Fixes an issue where NextJS would sometimes split the `typescript-result` package into separate bundles causing the `Result.isResult` check to fail.

### Type of Change

<!-- Please keep the relevant option and delete the rest. -->

- **Bug fix** (non-breaking change which fixes an issue)

### Changes Made

<!-- List the specific changes made in this PR -->

- Adds `typescript-result` to NextJS external packages.