### PR TITLE
Fix: add 100% width to openCameraButton

### DIFF
--- a/apps/website/src/components/JoinEvent/JoinEventCard.module.css
+++ b/apps/website/src/components/JoinEvent/JoinEventCard.module.css
@@ -31,7 +31,3 @@
   margin: 0;
   font-weight: var(--font-weight-bold);
 }
-
-.fullWidthButton {
-  width: 100%;
-}

--- a/apps/website/src/components/JoinEvent/JoinEventCard.tsx
+++ b/apps/website/src/components/JoinEvent/JoinEventCard.tsx
@@ -62,6 +62,7 @@ const JoinEventCard = () => {
                 className={styles.fullWidthButton}
                 variant="secondary"
                 data-color="brand-purple"
+                fill
               >
                 {t("openCameraButton")}
               </Button>


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of what this PR does -->
Adds 100% width to the "Åpne Kamera" button using the className "fullWidthButton" in JoinEventCard.module.css

### Type of Change

<!-- Please keep the relevant option and delete the rest. -->

- **Bug fix** (non-breaking change which fixes an issue)

### Related Issues

<!-- Link related issues using #issue_number or "Fixes #issue_number" to auto-close -->

- Fixes #200 

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
It solves the visual UI issue of the open camera button width not being 100%

### Changes Made

<!-- List the specific changes made in this PR -->

- Added 100% width to button

### Screenshots/Videos

<!-- If applicable, add screenshots or videos to demonstrate the changes -->
<!-- Before and after screenshots are especially helpful for UI changes -->
Before:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/0e955f69-fd4a-470b-afa2-75902c029e14" />
After:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/9eea7a5e-59fd-47e4-88a9-0efc98ce1b79" />


### Checklist

<!-- Check all that apply -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities
