### PR TITLE
Fix: Nickname page shows event name

### DIFF
--- a/apps/website/src/app/[locale]/join/[code]/page.tsx
+++ b/apps/website/src/app/[locale]/join/[code]/page.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import { useParams, useRouter } from "next/navigation";
 import { useState } from "react";
+import { useEventByCodeQuery, useEventsQuery } from "@/hooks/useEvents";
 
 export default function Page() {
   const navigation = useRouter();
@@ -12,6 +13,14 @@ export default function Page() {
   const cActions = useTranslations("common.actions");
   const cFields = useTranslations("common.fields");
   const { code } = useParams<{ code: string }>();
+  const joinCode = typeof code === "string" ? code : "";
+
+  const { data: eventCodeData } = useEventByCodeQuery(joinCode);
+  const { data: eventData } = useEventsQuery(
+    eventCodeData?.eventId ? { id: [eventCodeData.eventId] } : undefined,
+    !!eventCodeData?.eventId
+  );
+  const eventName = eventData?.[0]?.name;
 
   const [nickname, setNickname] = useState<string>("");
 
@@ -31,7 +40,7 @@ export default function Page() {
             data-color="brand-purple"
             description={tNickname("description")}
           >
-            {tNickname("title")}
+            {eventName ? `${tNickname("title")} ${eventName}` : tNickname("title")}
           </Title>
           <Input
             aria-label={cFields("nickname")}
@@ -42,7 +51,7 @@ export default function Page() {
             onChange={e => setNickname(e.target.value)}
             required
           />
-          <input hidden defaultValue={code} name="eventCode" />
+          <input hidden defaultValue={joinCode} name="eventCode" />
           <Button
             variant="primary"
             icon={<ArrowRight />}

--- a/apps/website/src/hooks/useEvents.ts
+++ b/apps/website/src/hooks/useEvents.ts
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { makeRequest } from "@/lib/utils/api";
 import {
   CreateEvent,
+  getEventCodeSchema,
   GetEventCodeParams,
   GetEventsParams,
   getEventSchema,
@@ -50,6 +51,7 @@ export const eventsKeys = {
     [...eventsKeys.all, "list", toEventsSearchParams(params)] as const,
   code: (eventId?: string, role: GetEventCodeParams["role"] = "guest") =>
     [...eventsKeys.all, eventId, "code", role] as const,
+  byCode: (code?: string) => [...eventsKeys.all, "by-code", code] as const,
 };
 
 /**
@@ -75,6 +77,17 @@ export function useEventCodeQuery(
     queryKey: eventsKeys.code(eventId, role),
     queryFn: () => makeRequest(z.string(), `/api/events/${eventId}/code?role=${role}`),
     enabled: !!eventId,
+  });
+}
+
+/**
+ * Resolves join code metadata for the event joining flow.
+ */
+export function useEventByCodeQuery(code?: string) {
+  return useQuery({
+    queryKey: eventsKeys.byCode(code),
+    queryFn: () => makeRequest(getEventCodeSchema, `/api/events/by-code/${code}`),
+    enabled: !!code,
   });
 }
 


### PR DESCRIPTION
### Description

The `Nickname` page now displays the name/title of the event the user in the process of joining

### Type of Change

- **Bug fix** (non-breaking change which fixes an issue)
- **New feature** (non-breaking change which adds functionality)

### Related Issues

- Fixes #214 

### Motivation and Context

`Nickname` page did not show the name of the event being joined, just "Welcome to"/"Velkommen til"

### Changes Made

<!-- List the specific changes made in this PR -->

- Made the `Nickname` page fetch event details based on the code of the event being joined
- Added display of the event name in the title of the `Nickname` page

### Screenshots/Videos

Before:
<img width="897" height="634" alt="image" src="https://github.com/user-attachments/assets/c5f5e1e3-b3ad-40b7-b067-9dbd86b86b26" />

After:
<img width="751" height="441" alt="image" src="https://github.com/user-attachments/assets/de6eb898-7e65-42f4-920f-937cf148dfc7" />

### Checklist

<!-- Check all that apply -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities
