### PR TITLE
Chore: Make event auth cookies httpOnly

### DIFF
--- a/apps/website/src/lib/utils/eventCookie.ts
+++ b/apps/website/src/lib/utils/eventCookie.ts
@@ -61,7 +61,11 @@ export function setEventCookie(
 ): AsyncResult<void, Error> {
   return Result.try(cookies).map(cs =>
     Result.try(() => jwt.sign({ eventId, userId, name, isModerator }, secret)).map(c => {
-      cs.set(`event-${eventId}`, c, { secure: true, maxAge: 10 * 24 * 60 * 60 });
+      cs.set(`event-${eventId}`, c, {
+        secure: process.env.NODE_ENV === "production",
+        httpOnly: true,
+        maxAge: 10 * 24 * 60 * 60,
+      });
     })
   );
 }


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of what this PR does -->

Changes event authentication cookies to be httpOnly. These cookies are only ever accessed on the server and an encapsulated eventAuth state is provided to the client.

Also sets the secure property to false when running in development mode.

### Type of Change

<!-- Please keep the relevant option and delete the rest. -->

- **Refactoring** (no functional changes)

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Since the event cookies were always secure they did not work under http in development mode.

### Changes Made

<!-- List the specific changes made in this PR -->

- Set the event session cookies as httpOnly
- Set the event session cookies as secure only in production

### Checklist

<!-- Check all that apply -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities