### PR TITLE
Fix: Add fontconfig to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:lts-alpine
 WORKDIR /opt/flash
 
+RUN apk add fontconfig font-dejavu ttf-freefont
+
 ENV CI=true
 RUN corepack enable pnpm
 


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of what this PR does -->

Adds fontconfig packages to docker image.

### Type of Change

<!-- Please keep the relevant option and delete the rest. -->

- **Bug fix** (non-breaking change which fixes an issue)

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Sharp needs fontconfig in order to convert from SVG images.

### Changes Made

<!-- List the specific changes made in this PR -->

- Added fontconfig to dockerfile

### Checklist

<!-- Check all that apply -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities