### PR TITLE
Limit uploads to one at a time

### DIFF
--- a/apps/website/src/app/[locale]/events/[id]/page.tsx
+++ b/apps/website/src/app/[locale]/events/[id]/page.tsx
@@ -101,6 +101,7 @@ export default function Page() {
   });
 
   const { openFilePicker, FileInput } = useFileUpload({
+    multiple: false,
     onFilesSelected: async files => {
       if (!eventId) {
         setUploadError(tUpload("errors.uploadUnavailable"));


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of what this PR does -->
This PR limits the number of uploaded images to one per upload request.

### Type of Change

<!-- Please keep the relevant option and delete the rest. -->

- **Bug fix** (non-breaking change which fixes an issue)

### Related Issues

<!-- Link related issues using #issue_number or "Fixes #issue_number" to auto-close -->

- Fixes #285 

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
The app crashes when uploading a lot of photos at once

### Changes Made

<!-- List the specific changes made in this PR -->

- Added `multiple: false` to `FileUpload`

### Checklist

<!-- Check all that apply -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities