### PR TITLE
Fix: Upload Image page always displays guest QR code

### DIFF
--- a/apps/website/src/app/[locale]/events/[id]/page.tsx
+++ b/apps/website/src/app/[locale]/events/[id]/page.tsx
@@ -38,10 +38,7 @@ export default function Page() {
   const { mutateAsync: uploadImage } = useUploadImageMutation();
 
   // Join Code
-  const { data: joinCode } = useEventCodeQuery(
-    eventId,
-    eventAuth.isModerator ? "moderator" : "guest"
-  );
+  const { data: joinCode } = useEventCodeQuery(eventId, "guest");
   const [joinLink, setJoinLink] = useState<string | null>(null);
   useEffect(() => {
     (async () =>


### PR DESCRIPTION
### Description

Made the Upload Image page always display the guest QR code and join code, even if the user is an administrator or moderator

### Type of Change

- **Bug fix** (non-breaking change which fixes an issue)

### Related Issues

- Fixes #289 

### Motivation and Context

Previously, the Upload Image page fetched a different `joinCode` based on whether the user was a guest or an admin/moderator. This was not clearly communicated to the user, and could have caused unintended leakage of privileged access

### Changes Made

- Change the `useEventCodeQuery` in the Upload Image page to only fetch guest `joinCode`

### How Has This Been Tested?

**Test Configuration**:

- **OS**: Windows 11
- **Version**: 0.1.0
- **Browser** (if applicable): Chrome

**Test Details**:

Manual testing in browser

### Checklist

<!-- Check all that apply -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities
