### PR TITLE
Fix: add copy button color variable

### DIFF
--- a/apps/website/src/components/EventDialogs/Steps/ReviewStep.tsx
+++ b/apps/website/src/components/EventDialogs/Steps/ReviewStep.tsx
@@ -34,6 +34,7 @@ const CopyButton = ({ isCopied, onCopy, ariaLabel }: CopyButtonProps) => (
       cursor: isCopied ? "default" : "pointer",
       background: "none",
       border: "none",
+      color: "var(--text-neutral)",
       padding: 0,
       display: "flex",
       alignItems: "center",


### PR DESCRIPTION
### Description

Added a color variable to the `CopyButton`

### Type of Change

- **Bug fix** (non-breaking change which fixes an issue)

### Related Issues

- Fixes #309 

### Motivation and Context

Previously, the color of the copy button lacked an explicit color and so constantly employed the browser default. When the application switched to dark mode, this made the button very difficult to spot.

### Changes Made

- Added a color variable to the `CopyButton` employed in `ReviewStep`, so that the color of the icon(s) changes when data-theme changes

### How Has This Been Tested?

**Test Configuration**:

- **OS**: Windows 11
- **Version**: 0.1.0
- **Browser** (if applicable): Chrome & Firefox

**Test Details**:

Tested visually

### Screenshots/Videos

Before:
<img width="422" height="347" alt="Image" src="https://github.com/user-attachments/assets/6264d67b-93d8-49cc-a675-4295b3fef8ba" />

After:
<img width="422" height="347" alt="image" src="https://github.com/user-attachments/assets/92797af5-83af-48ba-95b1-34bdc2aea652" />


### Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities