### PR TITLE
Fix: make scrolling show only when usable

### DIFF
--- a/apps/website/src/components/EventDialogs/CreateEventDialog.module.css
+++ b/apps/website/src/components/EventDialogs/CreateEventDialog.module.css
@@ -25,7 +25,7 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .buttonGroup {

--- a/apps/website/src/components/EventDialogs/Steps/Steps.module.css
+++ b/apps/website/src/components/EventDialogs/Steps/Steps.module.css
@@ -17,7 +17,7 @@
 }
 
 .scroll {
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 @media screen and (max-width: 768px) {


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of what this PR does -->
Make scrolling show only when usable in share dialog

### Type of Change

<!-- Please keep the relevant option and delete the rest. -->

- **Bug fix** (non-breaking change which fixes an issue)

### Related Issues

<!-- Link related issues using #issue_number or "Fixes #issue_number" to auto-close -->

- Fixes #224 

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
Makes user only able to see scollbars that can also be used

### Changes Made

<!-- List the specific changes made in this PR -->

- Switched forced scrolling to conditional scrolling in Steps.module.css and CreateEventDialog.module.css

### Screenshots/Videos

<!-- If applicable, add screenshots or videos to demonstrate the changes -->
<!-- Before and after screenshots are especially helpful for UI changes -->
Before:
<img width="1496" height="1204" alt="image" src="https://github.com/user-attachments/assets/7176683e-c5be-4889-983d-dce4835fd5d6" />

After:
<img width="1328" height="1214" alt="image" src="https://github.com/user-attachments/assets/a26d2ae4-cf3e-4fbb-83cb-686e5a71e3e4" />


### Checklist

<!-- Check all that apply -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities
