### PR TITLE
Added moderate button for moderate page navigation

### DIFF
--- a/apps/website/messages/locales/en/common.json
+++ b/apps/website/messages/locales/en/common.json
@@ -18,7 +18,8 @@
     "slideshow": "Slideshow",
     "createNewEvent": "Create New Event",
     "shareEvent": "Share Event",
-    "copyLink": "Copy Link"
+    "copyLink": "Copy Link",
+    "moderate": "Moderate"
   },
   "roles": {
     "guest": "Guest",

--- a/apps/website/messages/locales/no/common.json
+++ b/apps/website/messages/locales/no/common.json
@@ -18,7 +18,8 @@
     "slideshow": "Lysbildefremvisning",
     "createNewEvent": "Lag nytt arrangement",
     "shareEvent": "Del arrangement",
-    "copyLink": "Kopier lenke"
+    "copyLink": "Kopier lenke",
+    "moderate": "Moderer"
   },
   "roles": {
     "guest": "Gjest",

--- a/apps/website/src/app/[locale]/events/[id]/page.tsx
+++ b/apps/website/src/app/[locale]/events/[id]/page.tsx
@@ -1,16 +1,16 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
-import { ChevronLeft, ChevronRight, QrCode, Upload, X } from "lucide-react";
+import { ChevronLeft, ChevronRight, ImageMinus, QrCode, Upload, X } from "lucide-react";
 import styles from "./UploadImage.module.css";
 import { ActionCard, Button, Dialog, ImageCard, QRDisplay } from "@flash/ui";
 import { useFileUpload } from "@/hooks/useFileUpload";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { useParams, useRouter } from "next/navigation";
 import { useEventCodeQuery, useEventsQuery } from "@/hooks/useEvents";
 import { useImagesQuery, useUploadImageMutation } from "@/hooks/useImages";
 import { useEventAuth } from "@/providers/EventAuthContext";
 import { PhoneHeader } from "@/components/PhoneHeader/PhoneHeader";
-import { getAdminDashboardEventRoute, routes } from "@/lib/routes";
+import { getAdminDashboardEventRoute, getModerateEventRoute, routes } from "@/lib/routes";
 import Image from "next/image";
 
 export default function Page() {
@@ -22,6 +22,7 @@ export default function Page() {
 
   // Event Data
   const { id: eventId } = useParams<{ id: string }>();
+  const locale = useLocale();
   const { data, isLoading, isError } = useEventsQuery(
     eventId ? { id: [eventId] } : undefined
   );
@@ -259,7 +260,19 @@ export default function Page() {
             data-color="brand-purple"
             variant="secondary"
             onClick={() => dialogRef.current?.showModal()}
+            className={eventAuth.isModerator ? styles.desktopOnly : undefined}
           />
+          {eventAuth.isModerator && (
+            <Button
+              icon={<ImageMinus />}
+              iconPosition="right"
+              data-color="brand-purple"
+              variant="primary"
+              onClick={() => router.push(getModerateEventRoute(locale, eventId))}
+            >
+              {tCommon("actions.moderate")}
+            </Button>
+          )}
           <Button
             icon={<Upload />}
             iconPosition="right"

--- a/apps/website/src/lib/routes.ts
+++ b/apps/website/src/lib/routes.ts
@@ -35,3 +35,15 @@ export function getAdminDashboardEventsRoute(): string {
 export function getAdminDashboardEventRoute(eventId: string): string {
   return `${getAdminDashboardEventsRoute()}/${encodeURIComponent(eventId)}`;
 }
+
+/**
+ * Generates the route for the moderate page of a specific event.
+ * @param locale - The current locale (e.g. "en", "no").
+ * @param eventId - The unique identifier of the event.
+ * @return The URL path to the moderate page for the specified event.
+ *
+ * "/{locale}/events/{eventId}/moderate"
+ */
+export function getModerateEventRoute(locale: string, eventId: string): string {
+  return `/${locale}/events/${encodeURIComponent(eventId)}/moderate`;
+}


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of what this PR does -->
In the header there is now a moderate button instead of a show QR button (on mobile only)if the user is a moderator/admin. When in desktop mode, both the QR button and the moderate button is shown.
### Type of Change

<!-- Please keep the relevant option and delete the rest. -->

- **New feature** (non-breaking change which adds functionality)

### Related Issues

<!-- Link related issues using #issue_number or "Fixes #issue_number" to auto-close -->

- Related to #335 

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
There was no way for a moderator to navigate to the  moderator page.


### How Has This Been Tested?

<!-- Describe the testing you've performed -->
This has been tested manually by checking if the button is visible to only the moderator and not guest. 

### Checklist

<!-- Check all that apply -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities