### PR TITLE
Fixed remembered events bug

### DIFF
--- a/apps/website/src/components/RememberedEvents/RememberedEvents.tsx
+++ b/apps/website/src/components/RememberedEvents/RememberedEvents.tsx
@@ -9,11 +9,11 @@ import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import styles from "./RememberedEvents.module.css";
 
-const RememberedEvent = ({ name, uploadLimit }: Event) => {
+const RememberedEvent = ({ name, uploadLimit, id }: Event) => {
   const c = useTranslations("common");
   const navigation = useRouter();
   return (
-    <Card onClick={() => navigation.back()} className={styles.linkcard}>
+    <Card onClick={() => navigation.push(`/events/${id}`)} className={styles.linkcard}>
       <div className={styles.content}>
         <Title size="small">{name}</Title>
         <span>


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of what this PR does -->
The PR fixes a bug where the remembered events cards use `navigation.back` on click, which takes the user to the previously visited page instead of the correct event page. The actual behavior now is to be redirected to the event page (/[locale]/events/[eventId]).
### Type of Change

<!-- Please keep the relevant option and delete the rest. -->

- **Bug fix** (non-breaking change which fixes an issue)

### Related Issues

<!-- Link related issues using #issue_number or "Fixes #issue_number" to auto-close -->

- Fixes #339 

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
Fixes:
Expected Behavior
I expected to be redirected to the event page (/[locale]/events/[eventId]).

Actual Behavior (before fix)
Instead, I was redirected to the admin login page (/[locale]/admin).

### How Has This Been Tested?

<!-- Describe the testing you've performed -->
Tried to reproduce the bug after the fix was implemented and our expected behavior was achieved:
1. Join an event
2. Go to /[locale]/
3. Click "admin" link
4. Click "guest" link
5. Click on the previously joined event

### Checklist

<!-- Check all that apply -->

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] I have checked my code for security vulnerabilities