### PR TITLE
Fix: Correct back button route for moderators

### DIFF
--- a/apps/website/src/app/[locale]/events/[id]/page.tsx
+++ b/apps/website/src/app/[locale]/events/[id]/page.tsx
@@ -10,7 +10,7 @@ import { useEventCodeQuery, useEventsQuery } from "@/hooks/useEvents";
 import { useImagesQuery, useUploadImageMutation } from "@/hooks/useImages";
 import { useEventAuth } from "@/providers/EventAuthContext";
 import { PhoneHeader } from "@/components/PhoneHeader/PhoneHeader";
-import { getAdminDashboardEventRoute, routes } from "@/lib/routes";
+import { routes } from "@/lib/routes";
 import Image from "next/image";
 
 export default function Page() {
@@ -57,9 +57,7 @@ export default function Page() {
       typeof uploadsRemaining === "number" ? uploadsRemaining : tUpload("unlimited"),
   });
 
-  const backHref = eventAuth.isModerator
-    ? getAdminDashboardEventRoute(eventId)
-    : routes.root;
+  const backHref = routes.root;
 
   const { openFilePicker, FileInput } = useFileUpload({
     multiple: false,


### PR DESCRIPTION
### Description

Fixed an error in which moderators who pressed the `Back` button for an event were brought to the Admin Login page instead of the Guest Login Page

### Type of Change

- **Bug fix** (non-breaking change which fixes an issue)

### Related Issues

- Fixes #342 

### Motivation and Context

The navigation to the Admin Login page was misleading since moderators access events through the Guest Login page. It added an unnecessary and inconvenient additional layer of navigation

### Changes Made

- Changed `backHref` in the Event page to always redirect back to the Guest Login page, notwithstanding the role of the user

### How Has This Been Tested?

**Test Configuration**:

- **OS**: Windows 11
- **Version**: 0.1.0
- **Browser** (if applicable): Chrome

**Test Details**:

Tested manually

### Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities