### PR TITLE
Feat/moderate middleware

### DIFF
--- a/apps/website/src/lib/utils/proxy/__test__/eventRoute.test.ts
+++ b/apps/website/src/lib/utils/proxy/__test__/eventRoute.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 import { Result } from "typescript-result";
-import { checkEventCookie, getEventId, isEventRoute } from "../eventRoute";
+import {
+  checkEventCookie,
+  isModerator,
+  getEventId,
+  isEventRoute,
+  isModerateRoute,
+} from "../eventRoute";
 import { getEventCookie } from "@/lib/utils/eventCookie";
 
 const deleteCookieMock = vi.fn();
@@ -51,6 +57,58 @@ describe("getEventId", () => {
     expect(
       getEventId(new NextRequest("http://www.test.com/no/events/eventId/moderate"))
     ).toBe("eventId");
+  });
+});
+
+describe("isModerateRoute", () => {
+  it("Should correctly match moderate routes", () => {
+    expect(
+      isModerateRoute(new NextRequest("http://www.test.com/en/events/abc/moderate"))
+    ).toBe(true);
+    expect(
+      isModerateRoute(new NextRequest("http://www.test.com/no/events/eventId/moderate"))
+    ).toBe(true);
+  });
+
+  it("Should not match non-moderate routes", () => {
+    expect(isModerateRoute(new NextRequest("http://www.test.com/en/events/abc"))).toBe(false);
+    expect(
+      isModerateRoute(new NextRequest("http://www.test.com/en/events/abc/moderate/extra"))
+    ).toBe(false);
+    expect(
+      isModerateRoute(new NextRequest("http://www.test.com/en/events/abc/slideshow"))
+    ).toBe(false);
+    expect(
+      isModerateRoute(new NextRequest("http://www.test.com/en/not-events/abc/moderate"))
+    ).toBe(false);
+  });
+});
+
+describe("isModerator", () => {
+  it("Should return true when cookie has isModerator true", async () => {
+    getEventCookieMock.mockImplementationOnce(() =>
+      Result.fromAsync(async () => ({ isModerator: true }) as never)
+    );
+
+    expect(await isModerator("eventId")).toBe(true);
+  });
+
+  it("Should return false when cookie has isModerator false", async () => {
+    getEventCookieMock.mockImplementationOnce(() =>
+      Result.fromAsync(async () => ({ isModerator: false }) as never)
+    );
+
+    expect(await isModerator("eventId")).toBe(false);
+  });
+
+  it("Should return false when cookie is invalid or missing", async () => {
+    getEventCookieMock.mockImplementationOnce(() =>
+      Result.fromAsyncCatching(async () => {
+        throw new Error();
+      })
+    );
+
+    expect(await isModerator("eventId")).toBe(false);
   });
 });
 

--- a/apps/website/src/lib/utils/proxy/__test__/eventRoute.test.ts
+++ b/apps/website/src/lib/utils/proxy/__test__/eventRoute.test.ts
@@ -71,7 +71,9 @@ describe("isModerateRoute", () => {
   });
 
   it("Should not match non-moderate routes", () => {
-    expect(isModerateRoute(new NextRequest("http://www.test.com/en/events/abc"))).toBe(false);
+    expect(isModerateRoute(new NextRequest("http://www.test.com/en/events/abc"))).toBe(
+      false
+    );
     expect(
       isModerateRoute(new NextRequest("http://www.test.com/en/events/abc/moderate/extra"))
     ).toBe(false);

--- a/apps/website/src/lib/utils/proxy/eventRoute.ts
+++ b/apps/website/src/lib/utils/proxy/eventRoute.ts
@@ -4,6 +4,29 @@ import { getEventCookie } from "@/lib/utils/eventCookie";
 import { cookies } from "next/headers";
 
 /**
+ * Checks whether the request was made to the moderate sub-route of an event.
+ *
+ * @param request The request to check.
+ * @returns A boolean indicating whether the request targets an event moderate route.
+ */
+export function isModerateRoute(request: NextRequest): boolean {
+  return /^\/[^\/]+\/events\/[^\/]+\/moderate$/.test(request.nextUrl.pathname);
+}
+
+/**
+ * Checks whether the event cookie for the given event grants moderator access.
+ *
+ * @param eventId The event id to check the moderator flag for.
+ * @returns A promise that resolves to true if the cookie grants moderator access, false otherwise.
+ */
+export async function isModerator(eventId: string): Promise<boolean> {
+  return getEventCookie(eventId, JWT_SECRET).fold(
+    ({ isModerator }) => isModerator,
+    () => false
+  );
+}
+
+/**
  * Checks whether the request was made to a route that requires event session authentication.
  *
  * @param request The request to check.

--- a/apps/website/src/proxy.ts
+++ b/apps/website/src/proxy.ts
@@ -11,6 +11,8 @@ import {
   isEventRoute,
   getEventId,
   checkEventCookie,
+  isModerateRoute,
+  isModerator,
   isJoinRoute,
   getJoinCode,
   getEventByCode,
@@ -62,6 +64,12 @@ export default async function proxy(request: NextRequest): Promise<NextResponse>
     const isAuthenticated = await checkEventCookie(eventId);
     if (!isAuthenticated) {
       return NextResponse.redirect(new URL(`/`, request.url));
+    }
+
+    if (isModerateRoute(request) && !(await isModerator(eventId))) {
+      const locale =
+        request.nextUrl.pathname.match(/^\/([a-z]{2}(-[A-Z]{2})?)/)?.[1] ?? "en";
+      return NextResponse.redirect(new URL(`/${locale}/events/${eventId}`, request.url));
     }
   }
 

--- a/apps/website/src/proxy.ts
+++ b/apps/website/src/proxy.ts
@@ -67,9 +67,7 @@ export default async function proxy(request: NextRequest): Promise<NextResponse>
     }
 
     if (isModerateRoute(request) && !(await isModerator(eventId))) {
-      const locale =
-        request.nextUrl.pathname.match(/^\/([a-z]{2}(-[A-Z]{2})?)/)?.[1] ?? "en";
-      return NextResponse.redirect(new URL(`/${locale}/events/${eventId}`, request.url));
+      return NextResponse.redirect(new URL(`/events/${eventId}`, request.url));
     }
   }
 


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of what this PR does -->
Guests could access the moderate page by directly navigating to `/events/:id/moderate` via the URL. This PR adds a middleware-level guard that checks the `isModerator` flag from the event cookie and redirects non-moderators back to the event page before the page renders.
### Type of Change

<!-- Please keep the relevant option and delete the rest. -->

- **New feature** (non-breaking change which adds functionality)

### Related Issues

<!-- Link related issues using #issue_number or "Fixes #issue_number" to auto-close -->

- Related to #338 

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
The moderate page allows approving and rejecting uploaded images. There was no server-side enforcement preventing a guest (a valid event participant with `isModerator: false`) from accessing it directly by changing the URL. The fix is applied at the middleware layer so the page never renders for unauthorized users.

### How Has This Been Tested?

<!-- Describe the testing you've performed -->
  - Unit tests added for `isModerateRoute` verifies correct matching of moderate routes and rejection of non-moderate paths
  - Unit tests added for `isModerator` verifies `true` for moderator cookies, `false` for guest cookies, and `false` for missing/invalid cookies
  - Manual: joining an event as a guest and navigating to `/events/:id/moderate` redirects to the event page
  - Manual: joining as admin/moderator loads the moderate page normally

### Checklist

<!-- Check all that apply -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities