### PR TITLE
Fix: segmented control cuts off on mobile

### DIFF
--- a/packages/ui/src/components/Form/SegmentedControl/SegmentedControl.module.css
+++ b/packages/ui/src/components/Form/SegmentedControl/SegmentedControl.module.css
@@ -59,7 +59,6 @@
 
 .toggleGroup {
   color: inherit;
-  /* width: max(100%, 7.5rem); */
 
   border-radius: var(--radius-16);
   background-color: var(--color-bg);

--- a/packages/ui/src/components/Form/SegmentedControl/SegmentedControl.module.css
+++ b/packages/ui/src/components/Form/SegmentedControl/SegmentedControl.module.css
@@ -34,7 +34,7 @@
   }
 
   &[data-fill="true"] {
-    min-width: 100%;
+    width: 100%;
   }
 
   .label {
@@ -59,7 +59,7 @@
 
 .toggleGroup {
   color: inherit;
-  width: max(100%, 7.5rem);
+  /* width: max(100%, 7.5rem); */
 
   border-radius: var(--radius-16);
   background-color: var(--color-bg);
@@ -125,11 +125,4 @@
   left: var(--backdrop-pos);
 
   transition: left 0.2s ease-in-out;
-}
-
-@media (min-width: 480px) {
-  .controlButton {
-    min-width: max-content;
-    padding: 0 1.5rem;
-  }
 }


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of what this PR does -->
Fixes the issue of segmented controls being cut off on mobile

### Type of Change

<!-- Please keep the relevant option and delete the rest. -->

- **Bug fix** (non-breaking change which fixes an issue)

### Related Issues

<!-- Link related issues using #issue_number or "Fixes #issue_number" to auto-close -->

- Fixes #354 

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
It ensures the user experience is up to expectiations as the button does not get cut off anymore so the user can read the whole button descriptions

### Changes Made

<!-- List the specific changes made in this PR -->
In SegmentedControl.module.css:
- Removed min from datafill width
- Removed toggleGroup width
- Removed media query

### Screenshots/Videos

<!-- If applicable, add screenshots or videos to demonstrate the changes -->
<!-- Before and after screenshots are especially helpful for UI changes -->

### Checklist

<!-- Check all that apply -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities
