### PR TITLE
Feature/add download zip button

### DIFF
--- a/apps/website/__mocks__/hooks/useImages.mock.ts
+++ b/apps/website/__mocks__/hooks/useImages.mock.ts
@@ -6,6 +6,7 @@ import {
   BatchUpdateImageInput,
   CreateImageInput,
   DeleteImageInput,
+  DownloadImagesInput,
   UpdateImageInput,
 } from "@/hooks/useImages";
 import { mockQueryResult } from "./useQuery.mock";
@@ -105,6 +106,16 @@ export const defaultUploadedImageCountQueryReturn = {
   isLoading: false,
   isError: false,
 } as UseQueryResult<{ count: number }>;
+
+export const defaultDownloadImagesMutationReturn = {
+  mutateAsync: vi.fn().mockResolvedValue(undefined),
+  mutate: vi.fn(),
+  status: "idle",
+  isPending: false,
+  isSuccess: false,
+  isError: false,
+  reset: vi.fn(),
+} as unknown as UseMutationResult<void, Error, DownloadImagesInput>;
 
 // ---------------------------------------------------------------------------
 // State builders

--- a/apps/website/__mocks__/modules/useImages.mock.ts
+++ b/apps/website/__mocks__/modules/useImages.mock.ts
@@ -6,6 +6,7 @@ import {
   defaultUpdateImageMutationReturn,
   defaultBatchUpdateImageMutationReturn,
   defaultDeleteImageMutationReturn,
+  defaultDownloadImagesMutationReturn,
 } from "../hooks/useImages.mock";
 
 /**
@@ -40,4 +41,5 @@ export const imageHooksMock = () => ({
     ...defaultBatchUpdateImageMutationReturn,
   })),
   useDeleteImageMutation: vi.fn(() => ({ ...defaultDeleteImageMutationReturn })),
+  useDownloadImagesMutation: vi.fn(() => ({ ...defaultDownloadImagesMutationReturn })),
 });

--- a/apps/website/messages/locales/en/common.json
+++ b/apps/website/messages/locales/en/common.json
@@ -15,6 +15,7 @@
     "join": "Join Event",
     "toggleCamera": "{open, select, true {Close camera} other {Open camera}}",
     "uploadImage": "Upload Image",
+    "downloadImages": "Download Images",
     "slideshow": "Slideshow",
     "createNewEvent": "Create New Event",
     "shareEvent": "Share Event",
@@ -75,6 +76,7 @@
     "unlimited": {
       "short": "Unlimited uploads",
       "long": "You can upload unlimited photos"
-    }
+    },
+    "eventEnded" : "The event has ended"
   }
 }

--- a/apps/website/messages/locales/no/common.json
+++ b/apps/website/messages/locales/no/common.json
@@ -15,6 +15,7 @@
     "join": "Bli med",
     "toggleCamera": "{open, select, true {Lukk kamera} other {Åpne kamera}}",
     "uploadImage": "Last opp bilde",
+    "downloadImages": "Last ned bilder",
     "slideshow": "Lysbildefremvisning",
     "createNewEvent": "Lag nytt event",
     "shareEvent": "Del event",
@@ -75,6 +76,7 @@
     "unlimited": {
       "short": "Ubegrenset opplasting",
       "long": "Du kan laste opp ubegrenset med bilder"
-    }
+    },
+    "eventEnded" : "Eventet er ferdig"
   }
 }

--- a/apps/website/src/app/[locale]/(sidebar)/admin/dashboard/[id]/page.tsx
+++ b/apps/website/src/app/[locale]/(sidebar)/admin/dashboard/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEventCodeQuery, useEventsQuery } from "@/hooks/useEvents";
-import { ArrowLeft, ArrowRight, Share, Play } from "lucide-react";
+import { ArrowLeft, ArrowRight, Share, Play, Download } from "lucide-react";
 import { useParams } from "next/navigation";
 import { Button, Card, Dialog, Title } from "@flash/ui";
 import styles from "./page.module.css";
@@ -9,6 +9,7 @@ import { useRouter } from "next/navigation";
 import { ReviewStep } from "@/components/EventDialogs/Steps";
 import { useRef } from "react";
 import { useTranslations } from "next-intl";
+import { useDownloadImagesMutation } from "@/hooks/useImages";
 
 const Page = () => {
   const qrCodeRef = useRef<HTMLDialogElement>(null);
@@ -18,6 +19,7 @@ const Page = () => {
   const { id, locale } = useParams<{ id: string; locale: string }>();
   const { data: joinCode } = useEventCodeQuery(id, "moderator");
   const { data = [], status } = useEventsQuery({ id: [id?.toString() || ""] });
+  const { mutate: downloadImages } = useDownloadImagesMutation();
   const eventData = data[0];
   if (!eventData) return;
 
@@ -44,6 +46,14 @@ const Page = () => {
           <Title description={eventData?.description}>{eventData?.name}</Title>
         </div>
         <Card className={styles.card}>
+          <Button
+            data-color="brand-purple"
+            variant="secondary"
+            icon={<Download />}
+            onClick={() => downloadImages({ eventId: id })}
+          >
+            Download
+          </Button>
           <Button
             data-color="brand-purple"
             icon={<Share />}

--- a/apps/website/src/app/[locale]/(sidebar)/events/[id]/page.tsx
+++ b/apps/website/src/app/[locale]/(sidebar)/events/[id]/page.tsx
@@ -59,9 +59,6 @@ export default function Page() {
 
   //Event date data
   const now = new Date();
-  const isLive = eventData
-    ? now >= eventData.startDate && now <= eventData.endDate
-    : false;
   const isEnded = eventData ? now > eventData.endDate : false;
 
   // Translation strings

--- a/apps/website/src/app/[locale]/(sidebar)/events/[id]/page.tsx
+++ b/apps/website/src/app/[locale]/(sidebar)/events/[id]/page.tsx
@@ -60,8 +60,7 @@ export default function Page() {
   }, [setJoinLink, joinCode]);
 
   //Event date data
-  const now = new Date();
-  const isEnded = eventData ? now > eventData.endDate : false;
+  const isEnded = eventData ? new Date() > eventData.endDate : false;
 
   // Translation strings
   const eventName =

--- a/apps/website/src/app/[locale]/(sidebar)/events/[id]/page.tsx
+++ b/apps/website/src/app/[locale]/(sidebar)/events/[id]/page.tsx
@@ -18,6 +18,7 @@ import { useEventCodeQuery, useEventsQuery } from "@/hooks/useEvents";
 import { useEventAuth } from "@/providers/EventAuthContext";
 import { PhoneHeader } from "@/components/PhoneHeader/PhoneHeader";
 import {
+  useDownloadImagesMutation,
   useImagesQuery,
   useUploadedImageCountQuery,
   useUploadImageMutation,
@@ -30,6 +31,7 @@ export default function Page() {
   const tUpload = useTranslations("guest.event.upload");
   const eventAuth = useEventAuth();
   const dialogRef = useRef<HTMLDialogElement>(null);
+  const { mutate: downloadImages } = useDownloadImagesMutation();
 
   // Event Data
   const { id: eventId } = useParams<{ id: string }>();
@@ -308,11 +310,7 @@ export default function Page() {
             iconPosition="right"
             data-color="brand-purple"
             variant="primary"
-            onClick={
-              isEnded
-                ? () => (window.location.href = `/api/events/${eventId}/images/download`)
-                : openFilePicker
-            }
+            onClick={isEnded ? () => downloadImages({ eventId }) : openFilePicker}
             loading={isUploading}
             className={styles.desktopOnly}
           >
@@ -337,9 +335,7 @@ export default function Page() {
               text: isEnded
                 ? tCommon("actions.downloadImages")
                 : tCommon("actions.uploadImage"),
-              onClick: isEnded
-                ? () => (window.location.href = `/api/events/${eventId}/images/download`)
-                : openFilePicker,
+              onClick: isEnded ? () => downloadImages({ eventId }) : openFilePicker,
               loading: isUploading,
             }}
           />

--- a/apps/website/src/app/[locale]/(sidebar)/events/[id]/page.tsx
+++ b/apps/website/src/app/[locale]/(sidebar)/events/[id]/page.tsx
@@ -1,6 +1,14 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
-import { ChevronLeft, ChevronRight, ImageMinus, QrCode, Upload, X } from "lucide-react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Download,
+  ImageMinus,
+  QrCode,
+  Upload,
+  X,
+} from "lucide-react";
 import styles from "./UploadImage.module.css";
 import { ActionCard, Button, Dialog, ImageCard, QRDisplay } from "@flash/ui";
 import { useFileUpload } from "@/hooks/useFileUpload";
@@ -49,6 +57,13 @@ export default function Page() {
       setJoinLink(new URL(`/join/${joinCode}`, window.location.origin).href))();
   }, [setJoinLink, joinCode]);
 
+  //Event date data
+  const now = new Date();
+  const isLive = eventData
+    ? now >= eventData.startDate && now <= eventData.endDate
+    : false;
+  const isEnded = eventData ? now > eventData.endDate : false;
+
   // Translation strings
   const eventName =
     eventData?.name ??
@@ -61,8 +76,9 @@ export default function Page() {
       ? Math.max(0, eventData.uploadLimit - userImageCount)
       : undefined;
 
-  const uploadDescription =
-    typeof uploadsRemaining !== "number"
+  const uploadDescription = isEnded
+    ? tCommon("uploads.eventEnded")
+    : typeof uploadsRemaining !== "number"
       ? tCommon("uploads.unlimited.long")
       : uploadsRemaining === 0
         ? tCommon("uploads.none.long")
@@ -291,15 +307,19 @@ export default function Page() {
             </Button>
           )}
           <Button
-            icon={<Upload />}
+            icon={isEnded ? <Download /> : <Upload />}
             iconPosition="right"
             data-color="brand-purple"
             variant="primary"
-            onClick={openFilePicker}
+            onClick={
+              isEnded
+                ? () => (window.location.href = `/api/events/${eventId}/images/download`)
+                : openFilePicker
+            }
             loading={isUploading}
             className={styles.desktopOnly}
           >
-            {tCommon("actions.uploadImage")}
+            {isEnded ? tCommon("actions.downloadImages") : tCommon("actions.uploadImage")}
           </Button>
         </PhoneHeader>
         {!isLoading && (isError || !eventData) ? (
@@ -315,10 +335,14 @@ export default function Page() {
             descriptionColor={uploadError ? "danger" : undefined}
             primaryButton={{
               "data-color": "brand-purple",
-              icon: <Upload size={18} />,
+              icon: isEnded ? <Download size={18} /> : <Upload size={18} />,
               iconPosition: "right",
-              text: tCommon("actions.uploadImage"),
-              onClick: openFilePicker,
+              text: isEnded
+                ? tCommon("actions.downloadImages")
+                : tCommon("actions.uploadImage"),
+              onClick: isEnded
+                ? () => (window.location.href = `/api/events/${eventId}/images/download`)
+                : openFilePicker,
               loading: isUploading,
             }}
           />

--- a/apps/website/src/hooks/useImages.ts
+++ b/apps/website/src/hooks/useImages.ts
@@ -4,7 +4,7 @@ import {
   UpdateImage,
   uploadedImageCountSchema,
 } from "@/db";
-import { makeRequest } from "@/lib/utils/api";
+import readResponseError, { makeRequest } from "@/lib/utils/api";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import z from "zod";
 
@@ -185,7 +185,16 @@ export function useDeleteImageMutation() {
 export function useDownloadImagesMutation() {
   return useMutation({
     mutationFn: async ({ eventId }: DownloadImagesInput) => {
-      window.location.href = `/api/events/${eventId}/images/download`;
+      const response = await fetch(`/api/events/${eventId}/images/download`);
+      if (!response.ok) {
+        throw new Error(await readResponseError(response));
+      }
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.click();
+      URL.revokeObjectURL(url);
     },
   });
 }

--- a/apps/website/src/hooks/useImages.ts
+++ b/apps/website/src/hooks/useImages.ts
@@ -29,6 +29,10 @@ export type BatchUpdateImageInput = {
   isApproved: boolean;
 };
 
+export type DownloadImagesInput = {
+  eventId: string;
+};
+
 /**
  * Serializes `GetImages` filters into a URL query string.
  * Returns an empty string when no params are provided.
@@ -171,6 +175,17 @@ export function useDeleteImageMutation() {
       makeRequest(getImageSchema, `/api/events/${eventId}/images/${imageId}`, "DELETE"),
     onSuccess: async (_data, { eventId }) => {
       await queryClient.invalidateQueries({ queryKey: imagesKeys.event(eventId) });
+    },
+  });
+}
+
+/**
+ * Downloads all images for the given event as a zip file.
+ */
+export function useDownloadImagesMutation() {
+  return useMutation({
+    mutationFn: async ({ eventId }: DownloadImagesInput) => {
+      window.location.href = `/api/events/${eventId}/images/download`;
     },
   });
 }

--- a/apps/website/src/services/__test__/imageService.test.ts
+++ b/apps/website/src/services/__test__/imageService.test.ts
@@ -25,14 +25,14 @@ const mockEvents: (typeof eventTable.$inferInsert)[] = [
     id: "birthday",
     name: "Birthday",
     startDate: new Date(),
-    endDate: new Date(),
+    endDate: new Date(Date.now() + 86_400_000),
     autoApprove: false,
   },
   {
     id: "wedding",
     name: "Wedding",
     startDate: new Date(),
-    endDate: new Date(),
+    endDate: new Date(Date.now() + 86_400_000),
     autoApprove: true,
   },
 ];
@@ -255,12 +255,28 @@ describe("ImageService downloadImage", () => {
   });
 
   it("Should return an empty zip when no zip exists for event", async () => {
+    await imageService["dbService"].db
+      .update(eventTable)
+      .set({
+        startDate: new Date(Date.now() - 2 * 86_400_000),
+        endDate: new Date(Date.now() - 86_400_000),
+      })
+      .where(eq(eventTable.id, "birthday"));
+
     const result = await imageService.downloadImages("birthday").getOrThrow();
     const zip = new AdmZip(result);
     expect(zip.getEntries()).toHaveLength(0);
   });
 
   it("Should return the zip archive when it exists", async () => {
+    await imageService["dbService"].db
+      .update(eventTable)
+      .set({
+        startDate: new Date(Date.now() - 2 * 86_400_000),
+        endDate: new Date(Date.now() - 86_400_000),
+      })
+      .where(eq(eventTable.id, "wedding"));
+
     vi.spyOn(DatabaseService.prototype, "flush").mockImplementation(() => {});
 
     await imageService

--- a/apps/website/src/services/__test__/imageService.test.ts
+++ b/apps/website/src/services/__test__/imageService.test.ts
@@ -409,6 +409,38 @@ describe("ImageService uploadImage", () => {
     const weddingImages = await imageService.getImages("wedding").getOrThrow();
     expect(weddingImages.filter(image => image.userId === "john2")).toHaveLength(3);
   });
+
+  it("Should return Err when event has ended", async () => {
+    await imageService["dbService"].db
+      .update(eventTable)
+      .set({
+        startDate: new Date(Date.now() - 2 * 86_400_000),
+        endDate: new Date(Date.now() - 86_400_000),
+      }) // yesterday
+      .where(eq(eventTable.id, "wedding"));
+
+    mockedGetEventCookie.mockImplementationOnce(() =>
+      Result.fromAsync(async () => ({ userId: "john2" }) as EventCookie)
+    );
+
+    const result = await imageService.uploadImage("wedding", mockImageData[0]!);
+    Result.assertError(result);
+
+    const error = result.error as HTTPError;
+    expect(error).toBeInstanceOf(HTTPError);
+    expect(error.code).toBe(403);
+    expect(String(error.json ?? error.message)).toContain("Event has ended");
+  });
+
+  it("Should return Err when event is still live", async () => {
+    const result = await imageService.downloadImages("wedding");
+    Result.assertError(result);
+
+    const error = result.error as HTTPError;
+    expect(error).toBeInstanceOf(HTTPError);
+    expect(error.code).toBe(403);
+    expect(String(error.json ?? error.message)).toContain("Event is still live");
+  });
 });
 
 describe("ImageService updateImage", () => {

--- a/apps/website/src/services/imageService.ts
+++ b/apps/website/src/services/imageService.ts
@@ -11,6 +11,7 @@ import { eventTable, GetImagesParams, Image, imageTable, UpdateImage } from "@/d
 import sharp, { Sharp, SharpInput } from "sharp";
 import ShortUniqueId from "short-unique-id";
 import AdmZip from "adm-zip";
+import { verifyAccessToken } from "@/lib/utils/auth";
 
 const uid = new ShortUniqueId();
 
@@ -135,16 +136,21 @@ export class ImageService {
         () => new HTTPError(`User is not logged in to event with id: ${eventId}`, 403)
       );
 
-      const { autoApprove, uploadLimit } = yield* Result.try(() =>
+      const { autoApprove, uploadLimit, endDate } = yield* Result.try(() =>
         this.dbService.db
           .select({
             autoApprove: eventTable.autoApprove,
             uploadLimit: eventTable.uploadLimit,
+            endDate: eventTable.endDate,
           })
           .from(eventTable)
           .where(eq(eventTable.id, eventId))
           .limit(1)
       ).map(rows => getFirstRow(rows, `Event with id ${eventId} does not exist`));
+
+      if (new Date() > endDate) {
+        throw new HTTPError("Event has ended, uploads are closed", 403);
+      }
 
       const count = yield* this.getUploadedImageCountByUser(eventId, userId);
 
@@ -299,9 +305,29 @@ export class ImageService {
    * @returns A result containing the zip archive as a `Buffer` or an error.
    */
   downloadImages(eventId: string): AsyncResult<Buffer, Error> {
-    return this.storage.read(`${eventId}.zip`).recover(() => {
-      const zip = new AdmZip();
-      return Result.ok(zip.toBuffer());
+    return Result.genCatching(this, function* () {
+      const isAdmin = yield* Result.fromAsyncCatching(
+        verifyAccessToken()
+          .then(() => true)
+          .catch(() => false)
+      );
+
+      const { endDate } = yield* Result.try(() =>
+        this.dbService.db
+          .select({ endDate: eventTable.endDate })
+          .from(eventTable)
+          .where(eq(eventTable.id, eventId))
+          .limit(1)
+      ).map(rows => getFirstRow(rows, `Event with id ${eventId} does not exist`));
+
+      if (new Date() < endDate && !isAdmin) {
+        throw new HTTPError("Event is still live, downloads are not yet available", 403);
+      }
+
+      return this.storage.read(`${eventId}.zip`).recover(() => {
+        const zip = new AdmZip();
+        return Result.ok(zip.toBuffer());
+      });
     });
   }
 


### PR DESCRIPTION
### Description

Adds the ability to download a .zip archive containing all approved images for an event once the event is closed. The download functionality is available for both users and administrators.

Users automatically gain access to a download option when an event is closed.
Admins can download the archive directly from a new button in the event admin dashboard.

### Type of Change

- **New feature** (non-breaking change which adds functionality)

### Related Issues

- Fixes #356

### Motivation and Context

We want a way for users and admin to download a the pictures taken

### Changes Made

- Added a download button in the event admin dashboard for administrators.
- Ensured access is restricted to closed events only.

### Checklist

<!-- Check all that apply -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities
