### PR TITLE
Fix: Add missing translations

### DIFF
--- a/apps/website/messages/locales/en/app.json
+++ b/apps/website/messages/locales/en/app.json
@@ -1,6 +1,4 @@
 {
   "name": "FLASH",
-  "adminName": "FLASH Admin",
-  "description": "Manage your photo events with ease",
-  "subtitle": "Self-hosted Photo Event Management System"
+  "description": "Manage your photo events with ease"
 }

--- a/apps/website/messages/locales/en/app.json
+++ b/apps/website/messages/locales/en/app.json
@@ -1,4 +1,0 @@
-{
-  "name": "FLASH",
-  "description": "Manage your photo events with ease"
-}

--- a/apps/website/messages/locales/en/common.json
+++ b/apps/website/messages/locales/en/common.json
@@ -19,7 +19,6 @@
     "slideshow": "Slideshow",
     "createNewEvent": "Create New Event",
     "shareEvent": "Share Event",
-    "copyLink": "Copy Link",
     "moderate": "Moderate"
   },
   "roles": {
@@ -56,8 +55,6 @@
     "photos": "Photos"
   },
   "messages": {
-    "copySuccess": "Copied successfully!",
-    "copyFailed": "Failed to copy link to clipboard",
     "scanToUploadPhotos": "Scan to upload photos"
   },
   "slideshow": {

--- a/apps/website/messages/locales/en/guest.json
+++ b/apps/website/messages/locales/en/guest.json
@@ -25,7 +25,7 @@
         "missingNickname": "Please enter a nickname.",
         "nicknameTaken": "Nickname is already taken.",
         "joinFailed": "Unable to join event. Please try again.",
-        "invalidQr": "Not a valid QR code. Plase try again."
+        "invalidQr": "Not a valid QR code. Please try again."
       },
       "nickname": {
         "title": "Welcome to",

--- a/apps/website/messages/locales/en/pages.json
+++ b/apps/website/messages/locales/en/pages.json
@@ -1,8 +1,8 @@
 {
-  "adminLogin": {
-    "title": "FLASH Admin",
-    "description": "Manage your photo events with ease",
-    "subtitle": "Self-hosted Photo Event Management System"
+  "login": {
+    "title": "FLASH",
+    "description": "Self-hosted system for managing photo events",
+    "subtitle": "Manage your photo events with ease"
   },
   "joinEvent": {
     "title": "Join an Event",

--- a/apps/website/messages/locales/no/admin.json
+++ b/apps/website/messages/locales/no/admin.json
@@ -53,7 +53,7 @@
               "unlimited": "Uendelig"
             },
             "error": {
-              "required": "Velg en opplasningsgrense",
+              "required": "Velg en opplastningsgrense",
               "min": "Nedre grense er 1"
             }
           },

--- a/apps/website/messages/locales/no/app.json
+++ b/apps/website/messages/locales/no/app.json
@@ -1,6 +1,4 @@
 {
   "name": "FLASH",
-  "adminName": "FLASH Admin",
-  "description": "Administrer fotoeventene dine enkelt",
-  "subtitle": "Selvhostet system for administrasjon av fotoeventer"
+  "description": "Administrer fotoeventene dine enkelt"
 }

--- a/apps/website/messages/locales/no/app.json
+++ b/apps/website/messages/locales/no/app.json
@@ -1,4 +1,0 @@
-{
-  "name": "FLASH",
-  "description": "Administrer fotoeventene dine enkelt"
-}

--- a/apps/website/messages/locales/no/common.json
+++ b/apps/website/messages/locales/no/common.json
@@ -16,10 +16,9 @@
     "toggleCamera": "{open, select, true {Lukk kamera} other {Åpne kamera}}",
     "uploadImage": "Last opp bilde",
     "downloadImages": "Last ned bilder",
-    "slideshow": "Lysbildefremvisning",
+    "slideshow": "Bildefremvisning",
     "createNewEvent": "Lag nytt event",
     "shareEvent": "Del event",
-    "copyLink": "Kopier lenke",
     "moderate": "Moderer"
   },
   "roles": {
@@ -29,7 +28,7 @@
   },
   "navigation": {
     "admin": "Admin",
-    "events": "Events",
+    "events": "Eventer",
     "options": "Valg",
     "dashboard": "Kontrollpanel",
     "language": "Språk",
@@ -56,8 +55,6 @@
     "photos": "Bilder"
   },
   "messages": {
-    "copySuccess": "Kopiert!",
-    "copyFailed": "Klarte ikke å kopiere lenken til utklippstavlen",
     "scanToUploadPhotos": "Skann for å laste opp bilder"
   },
   "slideshow": {

--- a/apps/website/messages/locales/no/pages.json
+++ b/apps/website/messages/locales/no/pages.json
@@ -9,8 +9,8 @@
     "description": "Skriv inn eventkoden eller skann QR-koden for å bli med"
   },
   "dashboard": {
-    "title": "FLASH Admin",
-    "description": "Administrer fotoeventene dine enkelt",
+    "title": "Eventer",
+    "description": "Administrer eventene dine enkelt",
     "filter": {
       "search": {
         "title": "Søk"

--- a/apps/website/messages/locales/no/pages.json
+++ b/apps/website/messages/locales/no/pages.json
@@ -1,7 +1,12 @@
 {
-  "home": {
-    "title": "Hallo verden!",
-    "about": "Om oss"
+  "adminLogin": {
+    "title": "FLASH Admin",
+    "description": "Administrer fotoeventene dine enkelt",
+    "subtitle": "Selvhostet system for administrasjon av fotoeventer"
+  },
+  "joinEvent": {
+    "title": "Delta i et event",
+    "description": "Skriv inn eventkoden eller skann QR-koden for å bli med"
   },
   "dashboard": {
     "title": "FLASH Admin",
@@ -31,12 +36,8 @@
       }
     }
   },
-  "joinEvent": {
-    "title": "Delta i et event",
-    "description": "Skriv inn eventkoden eller skann QR-koden for å bli med"
-  },
-  "adminEvents": {
-    "title": "Eventer",
-    "description": "Administrer eventene dine"
+  "home": {
+    "title": "Hallo verden!",
+    "about": "Om oss"
   }
 }

--- a/apps/website/messages/locales/no/pages.json
+++ b/apps/website/messages/locales/no/pages.json
@@ -1,8 +1,8 @@
 {
-  "adminLogin": {
-    "title": "FLASH Admin",
-    "description": "Administrer fotoeventene dine enkelt",
-    "subtitle": "Selvhostet system for administrasjon av fotoeventer"
+  "login": {
+    "title": "FLASH",
+    "description": "Selvhostet system for administrasjon av fotoeventer",
+    "subtitle": "Administrer fotoeventene dine enkelt"
   },
   "joinEvent": {
     "title": "Delta i et event",

--- a/apps/website/src/app/[locale]/(sidebar)/admin/dashboard/[id]/page.tsx
+++ b/apps/website/src/app/[locale]/(sidebar)/admin/dashboard/[id]/page.tsx
@@ -52,7 +52,7 @@ const Page = () => {
             icon={<Download />}
             onClick={() => downloadImages({ eventId: id })}
           >
-            Download
+            {c("download")}
           </Button>
           <Button
             data-color="brand-purple"

--- a/apps/website/src/app/[locale]/admin/page.tsx
+++ b/apps/website/src/app/[locale]/admin/page.tsx
@@ -7,7 +7,7 @@ import { useTranslations } from "next-intl";
 import { LanguageToggleButton, ThemeToggleButton } from "@/components/ConfigButtons";
 
 export default function Page() {
-  const t = useTranslations("pages.adminLogin");
+  const t = useTranslations("pages.login");
   return (
     <div className={styles.pageWrapper}>
       <LanguageToggleButton />

--- a/apps/website/src/app/[locale]/page.test.tsx
+++ b/apps/website/src/app/[locale]/page.test.tsx
@@ -43,7 +43,7 @@ describe("Page", () => {
     renderWithQuery(<Page />);
 
     // Verify the translated text appears in the document
-    expect(screen.getByText("name")).toBeDefined();
-    expect(screen.getByText("description")).toBeDefined();
+    expect(screen.getByText("login.title")).toBeDefined();
+    expect(screen.getByText("login.description")).toBeDefined();
   });
 });

--- a/apps/website/src/app/[locale]/page.tsx
+++ b/apps/website/src/app/[locale]/page.tsx
@@ -8,15 +8,15 @@ import RememberedEvents from "@/components/RememberedEvents/RememberedEvents";
 import { LanguageToggleButton, ThemeToggleButton } from "@/components/ConfigButtons";
 
 const Page = () => {
-  const t = useTranslations("app");
+  const t = useTranslations("pages");
 
   return (
     <div className={styles.pageWrapper}>
       <LanguageToggleButton />
       <ThemeToggleButton />
       <Logo />
-      <Title align="center" size="large" as="h1" description={t("description")}>
-        {t("name")}
+      <Title align="center" size="large" as="h1" description={t("login.description")}>
+        {t("login.title")}
       </Title>
       <div className={styles.wrapper}>
         <JoinEventCard />

--- a/apps/website/src/i18n/request.ts
+++ b/apps/website/src/i18n/request.ts
@@ -2,7 +2,7 @@ import { getRequestConfig } from "next-intl/server";
 import { hasLocale } from "next-intl";
 import { routing } from "@/i18n/routing";
 
-const messageNamespaces = ["app", "common", "pages", "admin", "guest"] as const;
+const messageNamespaces = ["common", "pages", "admin", "guest"] as const;
 
 /* This file is responsible for loading the correct locale and messages based on request.
  * It uses the `getRequestConfig` function from `next-intl/server` to load the appropriate messages for the requested locale.


### PR DESCRIPTION
### Description

Adds the missing translation keys for the Admin Login page in the Norwegian (`no`) locale, as well as some other minor translation fixes

### Type of Change

- **Bug fix** (non-breaking change which fixes an issue)

### Related Issues

- Fixes #384 

### Motivation and Context

The missing translation keys made the application less accessible to users with limited non-Norwegian proficiency, and additionally made it look unfinished

### Changes Made

- Added translation keys for `title`, `description`, and `subtitle` to `adminLogin` 
- Added translation to hardcoded instance of "Download"
- Changed "Lysbildefremvisining" to "Bildefremvisning"
- Removed unused translations (including the `app.json` file)
- Corrected some minor spelling errors

### How Has This Been Tested?

Tested manually in browser

**Test Configuration**:

- **OS**: Windows 11
- **Version**: 0.1.0
- **Browser** (if applicable): Chrome

### Screenshots/Videos

Before:
<img width="755" height="767" alt="Image" src="https://github.com/user-attachments/assets/01a1ecf7-2e7c-4b30-b016-f04aaf7c0a20" />

After:
<img width="755" height="767" alt="image" src="https://github.com/user-attachments/assets/2312915e-3a46-442e-af52-77dd04b2d627" />


### Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities