### PR TITLE
Fix: Remove cookieStore refetch

### DIFF
--- a/apps/website/src/hooks/useAuth.ts
+++ b/apps/website/src/hooks/useAuth.ts
@@ -1,7 +1,7 @@
 "use client";
 import { makeRequest } from "@/lib/utils/api";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect } from "react";
+import { useEffect } from "react";
 import { z } from "zod";
 import { getAuth } from "@/actions/auth";
 import { usePathname, useSearchParams } from "next/navigation";
@@ -24,18 +24,10 @@ export function useAuth() {
   const searchParams = useSearchParams();
   const pathname = usePathname();
 
-  const invalidateQuery = useCallback(() => {
-    queryClient.invalidateQueries({ queryKey: authKeys.state() });
-  }, [queryClient]);
-
   // Refetch on URL change
-  useEffect(invalidateQuery, [pathname, searchParams, invalidateQuery]);
-
-  // Refetch on `cookieStore` change
   useEffect(() => {
-    cookieStore.addEventListener("change", invalidateQuery);
-    return () => cookieStore.removeEventListener("change", invalidateQuery);
-  }, [invalidateQuery]);
+    queryClient.invalidateQueries({ queryKey: authKeys.state() });
+  }, [pathname, searchParams, queryClient]);
 
   return useQuery({
     queryKey: authKeys.state(),

--- a/apps/website/src/hooks/useEvents.ts
+++ b/apps/website/src/hooks/useEvents.ts
@@ -13,7 +13,7 @@ import {
 } from "@/db";
 import z from "zod";
 import { usePathname, useSearchParams } from "next/navigation";
-import { useCallback, useEffect } from "react";
+import { useEffect } from "react";
 import { getJoinedEvents } from "@/actions/joinedEvents";
 
 /**
@@ -121,18 +121,10 @@ export function useJoinedEvents() {
   const searchParams = useSearchParams();
   const pathname = usePathname();
 
-  const invalidateQuery = useCallback(() => {
-    queryClient.invalidateQueries({ queryKey: eventsKeys.joined() });
-  }, [queryClient]);
-
   // Refetch on URL change
-  useEffect(invalidateQuery, [pathname, searchParams, invalidateQuery]);
-
-  // Refetch on `cookieStore` change
   useEffect(() => {
-    cookieStore.addEventListener("change", invalidateQuery);
-    return () => cookieStore.removeEventListener("change", invalidateQuery);
-  }, [invalidateQuery]);
+    queryClient.invalidateQueries({ queryKey: eventsKeys.joined() });
+  }, [pathname, searchParams, queryClient]);
 
   return useQuery({
     queryKey: eventsKeys.joined(),


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of what this PR does -->

`useAuth` and `useJoinedEvents` used to refetch when `cookieStore` changed. This could sometimes cause recursive rebuilds in the development server. 

`cookieStore` only catches cookies that are updated on the client. The only cookie updated on the client is `NEXT_LOCALE` which the hooks do not need to listen to anyway.

### Type of Change

<!-- Please keep the relevant option and delete the rest. -->

- **Bug fix** (non-breaking change which fixes an issue)

### Changes Made

<!-- List the specific changes made in this PR -->

- Removed `cookieStore` onchange listener in `useJoinedEvents` hook
- Removed `cookieStore` onchange listener in `useAuth` hook

### Checklist

<!-- Check all that apply -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities
