### PR TITLE
Fix admin tab visibility in sidebar

### DIFF
--- a/apps/website/src/components/Sidebar/Sidebar.tsx
+++ b/apps/website/src/components/Sidebar/Sidebar.tsx
@@ -21,7 +21,7 @@ export const Sidebar = ({ className, ...rest }: HTMLAttributes<HTMLDivElement>) 
 
   const { setOpen } = useSidebar();
 
-  const { data: isAdmin } = useAuth();
+  const { data: auth } = useAuth();
   const mounted = useIsMounted();
   const isMobile = useIsMobile();
   const navigation = useRouter();
@@ -50,7 +50,7 @@ export const Sidebar = ({ className, ...rest }: HTMLAttributes<HTMLDivElement>) 
   return (
     <FlashSidebar className={className} {...rest}>
       <FlashSidebar.Header logo={<Logo />}>FLASH</FlashSidebar.Header>
-      {isAdmin && (
+      {auth?.isAdmin && (
         <FlashSidebar.Group title={t("admin")}>
           <FlashSidebar.Item
             icon={<House />}


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of what this PR does -->
This PR makes the admin tab in the sidebar actually only apear for the admin.

### Type of Change

<!-- Please keep the relevant option and delete the rest. -->

- **Bug fix** (non-breaking change which fixes an issue)

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
It was not supost to be shown to guests.

### Changes Made

<!-- List the specific changes made in this PR -->

- Fixed the admin viewability

### How Has This Been Tested?

<!-- Describe the testing you've performed -->

**Test Configuration**:

- **OS**: Windows 11
- **Version**: 0.1.0
- **Browser** (if applicable): Firefox

<!-- Describe specific test cases or scenarios -->

### Checklist

<!-- Check all that apply -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities
