### PR TITLE
Fix: Admin login refresh

### DIFF
--- a/apps/website/src/lib/utils/api.ts
+++ b/apps/website/src/lib/utils/api.ts
@@ -37,8 +37,6 @@ let refreshPromise: Promise<void> | null = null;
 async function refreshAccessToken(): Promise<void> {
   const res = await fetch("/api/auth/refresh", { method: "POST" });
   if (!res.ok) {
-    const locale = document.cookie.match(/NEXT_LOCALE=([^;]+)/)?.[1] ?? "en";
-    window.location.href = `/${locale}/admin`;
     throw new Error(await readResponseError(res));
   }
 }
@@ -90,7 +88,7 @@ export async function makeRequest<T>(
   data?: JSONObject | Blob
 ): Promise<T> {
   const requestInit = await buildRequest(method, data);
-  const response = await fetch(endpoint, requestInit);
+  let response = await fetch(endpoint, requestInit);
 
   // On 401, attempt a single token refresh then retry
   if (response.status === 401) {
@@ -106,11 +104,7 @@ export async function makeRequest<T>(
     // All concurrent 401s wait for the same refresh
     await refreshPromise;
 
-    const retryResponse = await fetch(endpoint, requestInit);
-    if (!retryResponse.ok) {
-      throw new Error(await readResponseError(retryResponse));
-    }
-    return z.parseAsync(schema, await retryResponse.json().catch(() => undefined));
+    response = await fetch(endpoint, requestInit);
   }
 
   if (!response.ok) {


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of what this PR does -->

Prevent the admin login form from refreshing the page.
Also cleaned up `makeRequest` a little.

### Type of Change

<!-- Please keep the relevant option and delete the rest. -->

- **Bug fix** (non-breaking change which fixes an issue)
- **Refactoring** (no functional changes)

### Related Issues

<!-- Link related issues using #issue_number or "Fixes #issue_number" to auto-close -->

- Closes #396 

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

The admin login form would always refresh the page making it impossible to show an error message to the user.

### Changes Made

<!-- List the specific changes made in this PR -->

- Prevented `refreshAccessToken` from redirecting to `/[locale]/admin`.
- Cleaned up `makeRequest`

### Checklist

<!-- Check all that apply -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities