### PR TITLE
Fix logo scrolling in sidebar

### DIFF
--- a/packages/ui/src/components/Sidebar/Sidebar.module.css
+++ b/packages/ui/src/components/Sidebar/Sidebar.module.css
@@ -83,7 +83,7 @@
     .headerText {
       font-weight: var(--font-weight-bold);
       font-size: var(--font-size-heading-large);
-      overflow-x: hidden;
+      overflow: hidden;
       text-overflow: clip;
       text-align: center;
       width: min-content;


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of what this PR does -->
This PR fixes the bug where the logo in the sidebar would scroll when the screen was small.

### Type of Change

<!-- Please keep the relevant option and delete the rest. -->

- **Refactoring** (no functional changes)

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
The logo in the sidebar would scroll on small screens

### Changes Made

<!-- List the specific changes made in this PR -->

- Changed `overflow-x: hidden` to `overflow: hidden` for sidebar logo text


### Checklist

<!-- Check all that apply -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities
