### PR TITLE
Chore: move file-storage tests

### DIFF
--- a/packages/file-storage/src/implementations/__tests__/fsStorage.test.ts
+++ b/packages/file-storage/src/implementations/__tests__/fsStorage.test.ts
@@ -1,5 +1,5 @@
 import { jest, describe, it, afterEach, expect, beforeEach } from "@jest/globals";
-import { FSStorage } from "./fsStorage";
+import { FSStorage } from "../fsStorage";
 import upath from "upath";
 import { tmpdir } from "os";
 import fs from "fs";

--- a/packages/file-storage/src/implementations/__tests__/gcloudStorage.test.ts
+++ b/packages/file-storage/src/implementations/__tests__/gcloudStorage.test.ts
@@ -11,7 +11,7 @@ import {
 import { GenericContainer, StartedTestContainer } from "testcontainers";
 import { Bucket, Storage, File } from "@google-cloud/storage";
 import { Result } from "typescript-result";
-import { GcloudStorage } from "./gcloudStorage";
+import { GcloudStorage } from "../gcloudStorage";
 import { randomUUID } from "crypto";
 
 let container: StartedTestContainer;


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of what this PR does -->

Moves the `file-storage` implementation tests into their own `__tests__` folder.

### Type of Change

<!-- Please keep the relevant option and delete the rest. -->

- **Other (please describe)**: File cleanup

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Spring cleaning :cherry_blossom:

### Changes Made

<!-- List the specific changes made in this PR -->

- Moved `packages/file-storage/src/implementations/fsStorage.test.ts` to `packages/file-storage/src/implementation/__tests__/fsStorage.test.ts`.
- Moved `packages/file-storage/src/implementations/gcloudStorage.test.ts` to `packages/file-storage/src/implementation/__tests__/gcloudStorage.test.ts`.

### Checklist

<!-- Check all that apply -->

- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities
