### PR TITLE
Fixed `imageQuery` to fetch `approved` photos only on `slideshow` page

### DIFF
--- a/apps/website/src/app/[locale]/events/[id]/slideshow/page.tsx
+++ b/apps/website/src/app/[locale]/events/[id]/slideshow/page.tsx
@@ -41,7 +41,12 @@ const Page = () => {
   const { data: joinCode } = useEventCodeQuery(id, "guest");
   const { data: imageStats } = useEventStatsQuery(id);
 
-  const { data: imageData } = useImagesQuery(id, { approval: "pending" }, true, INTERVAL);
+  const { data: imageData } = useImagesQuery(
+    id,
+    { approval: "approved" },
+    true,
+    INTERVAL
+  );
   const [viewIndex, setViewIndex, { paused, toggle }] = useInterval(
     imageData?.length ?? 0,
     INTERVAL


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of what this PR does -->
This PR fixes the bug where the slideshow would only pull images with the status of `pending`. It is now `approved`.

### Type of Change

<!-- Please keep the relevant option and delete the rest. -->

- **Bug fix** (non-breaking change which fixes an issue)

### Related Issues

<!-- Link related issues using #issue_number or "Fixes #issue_number" to auto-close -->

- Fixes #418 

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
Only `approved` images should be shown on the slideshow

### Changes Made

<!-- List the specific changes made in this PR -->

- Changed `pending` to `approved` in the `imageQuery` on the `slideshow` page

### How Has This Been Tested?

<!-- Describe the testing you've performed -->

**Test Configuration**:

- **OS**: Windows 11
- **Version**: 0.1.0
- **Browser** (if applicable): FireFox


### Checklist

<!-- Check all that apply -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities