### PR TITLE
Fix edit event bug

### DIFF
--- a/apps/website/src/components/EventDialogs/EditEventDialog.tsx
+++ b/apps/website/src/components/EventDialogs/EditEventDialog.tsx
@@ -1,4 +1,4 @@
-import { RefAttributes, useEffect, useState } from "react";
+import { RefAttributes, useState } from "react";
 import { Button, Dialog, ProgressDots } from "@flash/ui";
 import { useTranslations } from "next-intl";
 import { useUpdateEventMutation } from "@/hooks/useEvents";
@@ -29,10 +29,6 @@ export const EditEventDialog = ({
     mode: "onChange",
   });
 
-  useEffect(() => {
-    methods.reset(event);
-  }, [event, methods]);
-
   const isOnFirstStep = currentStepIndex === 0;
   const isOnLastStep = currentStepIndex === FORM_STEPS.length - 1;
   const currentStep = FORM_STEPS[currentStepIndex]!;
@@ -55,7 +51,7 @@ export const EditEventDialog = ({
   };
 
   const handleClose = () => {
-    methods.reset();
+    methods.reset(methods.getValues());
     setCurrentStepIndex(0);
     setFormKey(i => i + 1);
     onClose?.();


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of what this PR does -->
This PR fixes a weir bug where the name of an event would only update the second time you try to edit it. 

### Type of Change

<!-- Please keep the relevant option and delete the rest. -->

- **Bug fix** (non-breaking change which fixes an issue)

### Related Issues

<!-- Link related issues using #issue_number or "Fixes #issue_number" to auto-close -->

- Fixes #417

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
The bug was unintended and editing it two times was weird.

### Changes Made

<!-- List the specific changes made in this PR -->

- Some changes in `EditEventDialog` (Honestly I have no idea what I did to make it work. Only think I know is that now it works)

### How Has This Been Tested?

<!-- Describe the testing you've performed -->
By editing an event multiple times and seeing if it updates appropriatly
**For the Reviewer**: Please check this yourself. Might have missed a combination.

**Test Configuration**:

- **OS**: Windows 11
- **Version**: 0.1.0
- **Browser** (if applicable): Firefox


### Checklist

<!-- Check all that apply -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities
