### PR TITLE
Fix: Moderate page pagination

### DIFF
--- a/apps/website/src/app/[locale]/(sidebar)/events/[id]/moderate/page.test.tsx
+++ b/apps/website/src/app/[locale]/(sidebar)/events/[id]/moderate/page.test.tsx
@@ -106,14 +106,14 @@ describe("ModeratePage", () => {
       renderWithQuery(<ModeratePage />);
 
       expect(screen.queryByRole("dialog")).toBeNull();
-      await userEvent.click(screen.getByTestId("image-1"));
+      await userEvent.click(screen.getAllByTestId("image-card")[0]!);
       expect(screen.getByRole("dialog")).toBeInTheDocument();
     });
 
     it("closes image preview when pressing Escape", async () => {
       renderWithQuery(<ModeratePage />);
 
-      await userEvent.click(screen.getByTestId("image-1"));
+      await userEvent.click(screen.getAllByTestId("image-card")[0]!);
       expect(screen.getByRole("dialog")).toBeInTheDocument();
 
       fireEvent.keyDown(window, { key: "Escape" });
@@ -137,17 +137,19 @@ describe("ModeratePage", () => {
       renderWithQuery(<ModeratePage />);
 
       await userEvent.click(screen.getByText("Select")); // Enter select mode
-      await userEvent.click(screen.getByTestId("image-1")); // Select an image via click
+      await userEvent.click(screen.getAllByTestId("image-card")[0]!); // Select an image via click
       await userEvent.click(screen.getByText("Cancel")); // Click Cancel
 
       expect(screen.getByText("Select")).toBeDefined(); // Button should revert to "Select"
       expect(screen.getByText("tabs.pending")).not.toBeDisabled(); // Tabs should be re-enabled
-      expect(screen.getByTestId("image-1").getAttribute("data-state")).toBe("default");
+      expect(screen.getAllByTestId("image-card")[0]!.getAttribute("data-state")).toBe(
+        "default"
+      );
     });
 
     it("tapping an image in select mode toggles its selected state", async () => {
       renderWithQuery(<ModeratePage />);
-      const imageCard = screen.getByTestId("image-1");
+      const imageCard = screen.getAllByTestId("image-card")[0]!;
 
       await userEvent.click(screen.getByText("Select"));
       await userEvent.click(imageCard);
@@ -161,15 +163,18 @@ describe("ModeratePage", () => {
       renderWithQuery(<ModeratePage />);
 
       await userEvent.click(screen.getByText("Select"));
-      await userEvent.click(screen.getByTestId("image-1"));
-      await userEvent.click(screen.getByTestId("image-2"));
+      await userEvent.click(screen.getAllByTestId("image-card")[0]!);
+      await userEvent.click(screen.getAllByTestId("image-card")[1]!);
 
       expect(screen.getByTestId("action-card")).toBeInTheDocument();
 
       await userEvent.click(screen.getByText("Cancel")); // Click Cancel in header
 
       expect(screen.queryByTestId("action-card")).not.toBeInTheDocument();
-      expect(screen.getByTestId("image-1")).toHaveAttribute("data-state", "default");
+      expect(screen.getAllByTestId("image-card")[0]!).toHaveAttribute(
+        "data-state",
+        "default"
+      );
     });
   });
 
@@ -182,14 +187,14 @@ describe("ModeratePage", () => {
 
       // Enter select mode and select an image via click
       await userEvent.click(screen.getByText("Select"));
-      await userEvent.click(screen.getByTestId("image-1"));
+      await userEvent.click(screen.getAllByTestId("image-card")[0]!);
 
       // ActionCard should be visible
       expect(screen.getByTestId("action-card")).toBeDefined();
       expect(screen.getByText("selectionDescription")).toBeInTheDocument();
 
       // Select another via click
-      await userEvent.click(screen.getByTestId("image-2"));
+      await userEvent.click(screen.getAllByTestId("image-card")[1]!);
       expect(screen.getByText("selectionDescription")).toBeInTheDocument();
     });
 
@@ -199,8 +204,8 @@ describe("ModeratePage", () => {
 
       // Enter select mode and select two images
       await userEvent.click(screen.getByText("Select"));
-      await userEvent.click(screen.getByTestId("image-1"));
-      await userEvent.click(screen.getByTestId("image-2"));
+      await userEvent.click(screen.getAllByTestId("image-card")[0]!);
+      await userEvent.click(screen.getAllByTestId("image-card")[1]!);
       await userEvent.click(screen.getByText("actions.approveSelected"));
 
       expect(mutateAsync).toHaveBeenCalledTimes(1);
@@ -224,7 +229,7 @@ describe("ModeratePage", () => {
 
       // Enter select mode and select one image
       await userEvent.click(screen.getByText("Select"));
-      await userEvent.click(screen.getByTestId("image-1"));
+      await userEvent.click(screen.getAllByTestId("image-card")[0]!);
       await userEvent.click(screen.getByText("actions.rejectSelected"));
 
       expect(mutateAsync).toHaveBeenCalledTimes(1);

--- a/apps/website/src/app/[locale]/(sidebar)/events/[id]/moderate/page.test.tsx
+++ b/apps/website/src/app/[locale]/(sidebar)/events/[id]/moderate/page.test.tsx
@@ -70,14 +70,14 @@ describe("ModeratePage", () => {
       expect(useImagesQuery).toHaveBeenCalledWith(
         "event-123",
         { approval: "pending" },
-        undefined,
+        true,
         PHOTOS_REFETCH_INTERVAL
       );
       await userEvent.click(screen.getByText("tabs.approved"));
       expect(useImagesQuery).toHaveBeenCalledWith(
         "event-123",
         { approval: "approved" },
-        undefined,
+        true,
         PHOTOS_REFETCH_INTERVAL
       );
     });

--- a/apps/website/src/app/[locale]/(sidebar)/events/[id]/moderate/page.tsx
+++ b/apps/website/src/app/[locale]/(sidebar)/events/[id]/moderate/page.tsx
@@ -134,6 +134,9 @@ export default function ModeratePage() {
           onClick={({ id, index }) =>
             selectMode ? handleImageClick(id) : imagePreviewRef.current?.open(index)
           }
+          setState={({ id }) =>
+            selectMode && selectedIds.has(id) ? "selected" : "default"
+          }
         />
       </div>
 

--- a/apps/website/src/app/[locale]/(sidebar)/events/[id]/moderate/page.tsx
+++ b/apps/website/src/app/[locale]/(sidebar)/events/[id]/moderate/page.tsx
@@ -10,6 +10,7 @@ import { useImageSelection } from "./useImageSelection";
 import { useTranslations } from "next-intl";
 import styles from "./Moderate.module.css";
 import { ImagePreview, ImagePreviewHandle } from "@/components/ImagePreview/ImagePreview";
+import { PhotoList } from "@/components/PhotoList/PhotoList";
 
 type Tab = "pending" | "approved" | "rejected";
 
@@ -21,13 +22,9 @@ export default function ModeratePage() {
 
   const [activeTab, setActiveTab] = useState<Tab>("pending");
 
-  const { data: imagesPages, isLoading } = useImagesQuery(eventId, {
-    approval: activeTab,
-  });
+  const imagesQuery = useImagesQuery(eventId, { approval: activeTab });
+  const { data: imagesPages, isLoading } = imagesQuery;
   const images = imagesPages?.pages.flatMap(page => page.items) ?? [];
-
-  // TODO: Replace with actual moderator check when JWT auth is implemented
-  // const isModerator = checkModeratorAccess(token);
 
   const {
     selectMode,
@@ -115,30 +112,14 @@ export default function ModeratePage() {
           <h2 className={styles.sectionHeading}>{t(`headings.${activeTab}`)}</h2>
         </div>
 
-        {!isLoading && images.length === 0 ? (
-          <div role="status" className={styles.emptyState}>
-            {t(`emptyState.${activeTab}`)}
-          </div>
-        ) : (
-          <div className={styles.grid}>
-            {images.map((image, index) => (
-              <ImageCard
-                key={image.id}
-                src={`/api/events/${eventId}/images/${image.id}`}
-                alt={t("imageAlt", { index: index + 1, total: images.length })}
-                title={t("imageTitle", { index: index + 1 })}
-                state={selectMode && selectedIds.has(image.id) ? "selected" : "default"}
-                onClick={() =>
-                  selectMode
-                    ? handleImageClick(image.id)
-                    : imagePreviewRef.current?.open(index)
-                }
-                data-testid={image.id}
-                placeholder={image.previewImage}
-              />
-            ))}
-          </div>
-        )}
+        <PhotoList
+          eventId={eventId}
+          query={imagesQuery}
+          loadingText={t(`emptyState.${activeTab}`)}
+          onClick={({ id, index }) =>
+            selectMode ? handleImageClick(id) : imagePreviewRef.current?.open(index)
+          }
+        />
       </div>
 
       <ImagePreview ref={imagePreviewRef} images={images} />

--- a/apps/website/src/app/[locale]/(sidebar)/events/[id]/page.tsx
+++ b/apps/website/src/app/[locale]/(sidebar)/events/[id]/page.tsx
@@ -293,6 +293,9 @@ export default function Page() {
           isShowingUserTab ? tUpload("userPhotosEmptyState") : tUpload("emptyState")
         }
         onClick={({ index }) => imagePreviewRef.current?.open(index)}
+        setState={({ isApproved }) =>
+          isApproved === null ? "pending" : isApproved === false ? "rejected" : undefined
+        }
       />
     </>
   );

--- a/apps/website/src/app/[locale]/(sidebar)/events/[id]/page.tsx
+++ b/apps/website/src/app/[locale]/(sidebar)/events/[id]/page.tsx
@@ -292,7 +292,7 @@ export default function Page() {
         loadingText={
           isShowingUserTab ? tUpload("userPhotosEmptyState") : tUpload("emptyState")
         }
-        onClick={index => imagePreviewRef.current?.open(index)}
+        onClick={({ index }) => imagePreviewRef.current?.open(index)}
       />
     </>
   );

--- a/apps/website/src/components/ImageCard/ImageCard.tsx
+++ b/apps/website/src/components/ImageCard/ImageCard.tsx
@@ -7,7 +7,7 @@ import { useTranslations } from "next-intl";
 import { cl } from "@/utils/className";
 import styles from "./ImageCard.module.css";
 
-type ImageCardState =
+export type ImageCardState =
   | "loading"
   | "rejected"
   | "approved"

--- a/apps/website/src/components/PhotoList/PhotoList.tsx
+++ b/apps/website/src/components/PhotoList/PhotoList.tsx
@@ -1,9 +1,9 @@
-import { GetImagesPage } from "@/db";
+import { GetImagesPage, Image } from "@/db";
 import { useLoadMore } from "@/hooks/useLoadMore";
 import { InfiniteData, UseInfiniteQueryResult } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import { FC } from "react";
-import ImageCard from "../ImageCard/ImageCard";
+import ImageCard, { ImageCardState } from "../ImageCard/ImageCard";
 import { getImageSrc } from "@/lib/utils/images";
 import styles from "./PhotoList.module.css";
 
@@ -11,6 +11,7 @@ export type PhotoListProps = {
   eventId: string;
   query: UseInfiniteQueryResult<InfiniteData<GetImagesPage>>;
   loadingText: string;
+  setState?: (image: Image) => ImageCardState | undefined;
   onClick?: (_: { id: string; index: number }) => void;
 };
 
@@ -18,6 +19,7 @@ export const PhotoList: FC<PhotoListProps> = ({
   eventId,
   query,
   loadingText,
+  setState,
   onClick,
 }) => {
   const tUpload = useTranslations("guest.event.upload");
@@ -45,15 +47,9 @@ export const PhotoList: FC<PhotoListProps> = ({
             total: images.length,
           })}
           title={tUpload("imageTitle", { index: index + 1 })}
-          data-image-id={image.id}
+          data-testid={image.id}
           placeholder={image.previewImage}
-          state={
-            image.isApproved === null
-              ? "pending"
-              : image.isApproved === false
-                ? "rejected"
-                : undefined
-          }
+          state={setState && setState(image)}
           onClick={() => onClick && onClick({ id: image.id, index })}
         />
       ))}

--- a/apps/website/src/components/PhotoList/PhotoList.tsx
+++ b/apps/website/src/components/PhotoList/PhotoList.tsx
@@ -11,7 +11,7 @@ export type PhotoListProps = {
   eventId: string;
   query: UseInfiniteQueryResult<InfiniteData<GetImagesPage>>;
   loadingText: string;
-  onClick?: (idx: number) => void;
+  onClick?: (_: { id: string; index: number }) => void;
 };
 
 export const PhotoList: FC<PhotoListProps> = ({
@@ -54,7 +54,7 @@ export const PhotoList: FC<PhotoListProps> = ({
                 ? "rejected"
                 : undefined
           }
-          onClick={() => onClick && onClick(index)}
+          onClick={() => onClick && onClick({ id: image.id, index })}
         />
       ))}
       {hasNextPage && <div ref={loadMoreRef} className={styles.loadMoreSentinel} />}

--- a/apps/website/src/components/PhotoList/PhotoList.tsx
+++ b/apps/website/src/components/PhotoList/PhotoList.tsx
@@ -47,7 +47,6 @@ export const PhotoList: FC<PhotoListProps> = ({
             total: images.length,
           })}
           title={tUpload("imageTitle", { index: index + 1 })}
-          data-testid={image.id}
           placeholder={image.previewImage}
           state={setState && setState(image)}
           onClick={() => onClick && onClick({ id: image.id, index })}


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of what this PR does -->

Updates the moderate page to use the new `PhotoList` component which includes correct handling of paginated queries.


### Type of Change

<!-- Please keep the relevant option and delete the rest. -->

- **Bug fix** (non-breaking change which fixes an issue)

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

The moderate page only fetched one page of images and had no way of fetching more.

### Changes Made

<!-- List the specific changes made in this PR -->

- Updated `/events/[id]/moderate/page.tsx` to use `PhotoList`.
- Added `setState` prop to `PhotoList`.
- Updated page unit tests.

### Checklist

<!-- Check all that apply -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities
