### PR TITLE
Fix: Correct private image toggle

### DIFF
--- a/apps/website/src/app/[locale]/(sidebar)/events/[id]/page.test.tsx
+++ b/apps/website/src/app/[locale]/(sidebar)/events/[id]/page.test.tsx
@@ -62,7 +62,7 @@ describe("Guest Upload Page", () => {
       expect(useImagesQuery).toHaveBeenCalledWith(
         "event-123",
         { approval: "approved", pageSize: 12 },
-        false,
+        true,
         expect.any(Number)
       );
     });
@@ -94,7 +94,7 @@ describe("Guest Upload Page", () => {
     });
 
     it("navigates preview with ArrowRight and ArrowLeft", async () => {
-      vi.mocked(useMyImagesQuery).mockReturnValue(
+      vi.mocked(useImagesQuery).mockReturnValue(
         mockImagesLoaded([
           makeImage({ id: "image-1" }),
           makeImage({ id: "image-2" }),
@@ -131,7 +131,7 @@ describe("Guest Upload Page", () => {
     });
 
     it("wraps preview to last image when pressing ArrowLeft on first image", async () => {
-      vi.mocked(useMyImagesQuery).mockReturnValue(
+      vi.mocked(useImagesQuery).mockReturnValue(
         mockImagesLoaded([
           makeImage({ id: "image-1" }),
           makeImage({ id: "image-2" }),

--- a/apps/website/src/app/[locale]/(sidebar)/events/[id]/page.tsx
+++ b/apps/website/src/app/[locale]/(sidebar)/events/[id]/page.tsx
@@ -65,7 +65,7 @@ export default function Page() {
   const eventData = data?.pages[0]?.items[0];
   const uploadsArePrivate = eventData?.uploadsArePrivate ?? false;
   const [activeTab, setActiveTab] = useState<"all" | "user">("all");
-  const showTabs = uploadsArePrivate || !!eventAuth.isModerator;
+  const showTabs = !uploadsArePrivate || eventAuth.isModerator === true;
   const isShowingUserTab = !showTabs || activeTab === "user";
 
   const handleTabChange = (val: string) => {

--- a/apps/website/src/components/EventDialogs/Steps/OptionsStep.tsx
+++ b/apps/website/src/components/EventDialogs/Steps/OptionsStep.tsx
@@ -78,18 +78,18 @@ export const OptionsStep = () => {
       <Controller
         control={control}
         name="uploadsArePrivate"
-        defaultValue={false}
+        defaultValue={true}
         render={({ field }) => (
           <Switch
             position="right"
             description={t("fields.guestCanViewAll.description")}
-            checked={field.value}
-            onChange={e => field.onChange(e.target.checked)}
+            checked={!field.value}
+            onChange={e => field.onChange(!e.target.checked)}
           >
             <b>{t("fields.guestCanViewAll.title")}</b>
           </Switch>
         )}
-      />{" "}
+      />
     </>
   );
 };


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of what this PR does -->

Changes the `uploadsArePrivate` edit event toggle to match the text on screen.

### Type of Change

<!-- Please keep the relevant option and delete the rest. -->

- **Bug fix** (non-breaking change which fixes an issue)

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

The `uploadsArePrivate` toggle was set to the opposite of what the description says, making it very confusing.

### Changes Made

<!-- List the specific changes made in this PR -->

- Inverted the `uploadsArePrivate` toggle in `OptionsStep`
- Corrected `showTabs` condition in `/events/[eventId]/page.tsx`

<!-- Check all that apply -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities