### PR TITLE
Fix: Slideshow event stats refetch

### DIFF
--- a/apps/website/src/app/[locale]/events/[id]/slideshow/page.tsx
+++ b/apps/website/src/app/[locale]/events/[id]/slideshow/page.tsx
@@ -41,7 +41,7 @@ const Page = () => {
   const eventData = data?.pages[0]?.items[0];
 
   const { data: joinCode } = useEventCodeQuery(id, "guest");
-  const { data: imageStats } = useEventStatsQuery(id);
+  const { data: imageStats } = useEventStatsQuery(id, SLIDESHOW_SLIDE_DURATION);
 
   const {
     data: imagePages,

--- a/apps/website/src/hooks/useEvents.ts
+++ b/apps/website/src/hooks/useEvents.ts
@@ -122,11 +122,12 @@ export function useEventByCodeQuery(code?: string) {
  * @param eventId The event to fetch the stats for.
  * @returns A `UseQueryResult` tracked stats for the specified event or an error.
  */
-export function useEventStatsQuery(eventId?: string) {
+export function useEventStatsQuery(eventId?: string, refetchInterval?: number) {
   return useQuery({
     queryKey: eventsKeys.stats(eventId),
     queryFn: () => makeRequest(getEventStatsSchema, `/api/events/${eventId}/stats`),
     enabled: !!eventId,
+    refetchInterval,
   });
 }
 


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of what this PR does -->

Adds a refetch interval to the `useEventStatsQuery` hook on the slideshow page.

### Type of Change

<!-- Please keep the relevant option and delete the rest. -->

- **Bug fix** (non-breaking change which fixes an issue)

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

The total number of images on the slideshow page was not updating as new image pages were being loaded.

### Changes Made

<!-- List the specific changes made in this PR -->

- Added a `refetchInterval` parameter to `useEventStatsQuery`

### Checklist

<!-- Check all that apply -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities