### PR TITLE
Fix: Center image preview nav buttons

### DIFF
--- a/apps/website/src/components/ImagePreview/ImagePreview.module.css
+++ b/apps/website/src/components/ImagePreview/ImagePreview.module.css
@@ -49,20 +49,17 @@
 
   .previewNavButtonLeft,
   .previewNavButtonRight {
-    width: 2.75rem;
-    height: 2.75rem;
     top: auto;
+    left: auto;
+    right: auto;
     bottom: calc(1rem + env(safe-area-inset-bottom));
-    transform: none;
   }
 
   .previewNavButtonLeft {
-    left: calc(50% - 3rem);
-    right: auto;
+    margin-right: 5rem;
   }
 
   .previewNavButtonRight {
-    left: calc(50% + 1.25rem);
-    right: auto;
+    margin-left: 5rem;
   }
 }


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of what this PR does -->

Properly centers the image preview navigation buttons when on smaller screens.

### Type of Change

<!-- Please keep the relevant option and delete the rest. -->

- **Bug fix** (non-breaking change which fixes an issue)

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

The navigation buttons in the image preview were slightly off center when on smaller screens.

### Changes Made

<!-- List the specific changes made in this PR -->

- Updated `ImagePreview` css

### Checklist

<!-- Check all that apply -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities
