### PR TITLE
Segmented control index backdrop renders outside component

### DIFF
--- a/packages/ui/src/components/Form/SegmentedControl/SegmentedControl.tsx
+++ b/packages/ui/src/components/Form/SegmentedControl/SegmentedControl.tsx
@@ -95,9 +95,10 @@ const SegmentedControl = ({
 
   const cssVars = {
     "--item-count": React.Children.count(children),
-    "--selected-index": descendants
-      .values()
-      .findIndex(d => d.value === context.selectedValue),
+    "--selected-index": Math.max(
+      0,
+      descendants.values().findIndex(d => d.value === context.selectedValue)
+    ),
   } as React.CSSProperties;
 
   return (


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of what this PR does -->
Segmented control index backdrop renders outside component when initially mounting
Segmented control index backdrop renders outside component when initially mounting, it defaults to index -1 making the backdrop of the selected tab render to the left side when initially mounting. The PR fixed this.
### Type of Change

<!-- Please keep the relevant option and delete the rest. -->

- **Bug fix** (non-breaking change which fixes an issue)

### Related Issues

<!-- Link related issues using #issue_number or "Fixes #issue_number" to auto-close -->

- Fixes #442 

### Checklist

<!-- Check all that apply -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities