### PR TITLE
Bug: Better success message when uploading photo

### DIFF
--- a/apps/website/messages/locales/en/guest.json
+++ b/apps/website/messages/locales/en/guest.json
@@ -96,7 +96,7 @@
       "emptyState": "No photos found",
       "imageAlt": "Photo {index} of {total}",
       "imageTitle": "Photo {index}",
-      "success": { "title": "Success", "message": "All photos have been uploaded" },
+      "success": { "title": "Success", "message": "Upload successful" },
       "errors": {
         "uploadUnavailable": "Unable to upload images for this event.",
         "uploadFailedTitle": "Upload Failed",

--- a/apps/website/messages/locales/no/guest.json
+++ b/apps/website/messages/locales/no/guest.json
@@ -99,7 +99,7 @@
 
       "success": {
         "title": "Sukses",
-        "message": "Alle bilder har blitt lastet opp"
+        "message": "Opplasting fullført"
       },
       "errors": {
         "uploadUnavailable": "Kan ikke laste opp bilder for dette eventet.",


### PR DESCRIPTION
### Description

Give a better success message when uploading photo

### Type of Change

- **Bug fix** (non-breaking change which fixes an issue)


### Related Issues
- Fixes #445 

### Motivation and Context

Bit unclear message when uploading a image successfully

### Changes Made

- Updated success message for uploading a photo in English and Norwegian 
