### PR TITLE
Fix back button in `Sidebar` 

### DIFF
--- a/packages/ui/src/components/Sidebar/Sidebar.module.css
+++ b/packages/ui/src/components/Sidebar/Sidebar.module.css
@@ -11,7 +11,7 @@
   max-width: 40rem;
 
   flex: 0 0 auto;
-  height: 100vh;
+  height: 100dvh;
   padding: 0 1rem;
 
   display: flex;


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of what this PR does -->
This PR fixes the Safari iOS backbutton problem.

### Type of Change

<!-- Please keep the relevant option and delete the rest. -->

- **Bug fix** (non-breaking change which fixes an issue)


### Related Issues

<!-- Link related issues using #issue_number or "Fixes #issue_number" to auto-close -->

- Fixes #430 


### Changes Made

<!-- List the specific changes made in this PR -->

- Made sidebar use `100dvh` instead of `100vh`

### How Has This Been Tested?

<!-- Describe the testing you've performed -->

**Test Configuration**:

- **OS**: Windows 11
- **Version**: 0.1.0
- **Browser** (if applicable): Firefox


### Screenshots/Videos

<!-- If applicable, add screenshots or videos to demonstrate the changes -->
<!-- Before and after screenshots are especially helpful for UI changes -->

**Before / After**

<img height="500" alt="IMG_2921" src="https://github.com/user-attachments/assets/6a14527e-81ee-403a-a6a1-9ed4b4e92a42" />

<img height="500" alt="IMG_2920" src="https://github.com/user-attachments/assets/09b48ddd-a464-4cbc-83df-948bbf05fc2a" />


### Checklist

<!-- Check all that apply -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities
