### PR TITLE
Fix: Sidebar provider

### DIFF
--- a/apps/website/src/app/[locale]/(sidebar)/layout.tsx
+++ b/apps/website/src/app/[locale]/(sidebar)/layout.tsx
@@ -1,15 +1,18 @@
 "use client";
 
 import Sidebar from "@/components/Sidebar/Sidebar";
+import { Sidebar as FlashSidebar } from "@flash/ui";
 import styles from "./layout.module.css";
 
 export default function Layout({ children }: LayoutProps<"/[locale]">) {
   return (
-    <div className={styles.layout}>
-      <Sidebar />
-      <div className={styles.content}>
-        <main className={styles.main}>{children}</main>
+    <FlashSidebar.Provider open={false}>
+      <div className={styles.layout}>
+        <Sidebar />
+        <div className={styles.content}>
+          <main className={styles.main}>{children}</main>
+        </div>
       </div>
-    </div>
+    </FlashSidebar.Provider>
   );
 }

--- a/apps/website/src/app/layout.tsx
+++ b/apps/website/src/app/layout.tsx
@@ -7,7 +7,6 @@ import { NextIntlClientProvider } from "next-intl";
 import { Geist, Geist_Mono } from "next/font/google";
 import { cookies } from "next/headers";
 import "./globals.css";
-import SidebarProvider from "@/providers/SidebarProvider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -53,9 +52,7 @@ export default async function RootLayout({
         <NextIntlClientProvider>
           <ReactQueryProvider>
             <ThemeProvider defaultTheme={"system"}>
-              <SidebarProvider>
-                <ToastProvider>{children}</ToastProvider>
-              </SidebarProvider>
+              <ToastProvider>{children}</ToastProvider>
             </ThemeProvider>
           </ReactQueryProvider>
         </NextIntlClientProvider>

--- a/apps/website/src/providers/SidebarProvider.tsx
+++ b/apps/website/src/providers/SidebarProvider.tsx
@@ -1,8 +1,0 @@
-"use client";
-
-import { Sidebar } from "@flash/ui";
-
-const SidebarProvider = ({ children }: { children: React.ReactNode }) => {
-  return <Sidebar.Provider open={false}>{children}</Sidebar.Provider>;
-};
-export default SidebarProvider;


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of what this PR does -->

Moves the `SidebarProvider` into `(sidebar)/layout.tsx`.

### Type of Change

<!-- Please keep the relevant option and delete the rest. -->

- **Bug fix** (non-breaking change which fixes an issue)

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

The `SidebarProvider` was mounted in the root `layout.tsx`, which persisted the open state event when navigating away from pages with the sidebar.

**Reproduction steps**:
1. Join event
2. Open sidebar
3. Leave event (Back button or navigate to `/`)
4. Rejoin event
5. Sidebar starts open

### Changes Made

<!-- List the specific changes made in this PR -->

- Deleted `apps/website/src/providers/SidebarProvider.tsx`
- Removed `SidebarProvider` from `apps/website/src/app/layout.tsx`
- Added `FlashSidebar.Provider` to `apps/website/src/app/[locale]/(sidebar)/layout.tsx`

### Checklist

<!-- Check all that apply -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities