### PR TITLE
Fix: ReviewStep mobile overflow

### DIFF
--- a/apps/website/src/components/EventDialogs/Steps/ReviewStep.tsx
+++ b/apps/website/src/components/EventDialogs/Steps/ReviewStep.tsx
@@ -52,7 +52,6 @@ const ReviewStep = ({ status, result }: ReviewStepProps) => {
       <SegmentedControl
         onChange={role => setRole(role as "guest" | "moderator")}
         value={role}
-        className={styles.scroll}
         fill
       >
         <SegmentedControl.Item label="Guest" value="guest" />

--- a/apps/website/src/components/EventDialogs/Steps/Steps.module.css
+++ b/apps/website/src/components/EventDialogs/Steps/Steps.module.css
@@ -16,10 +16,6 @@
   gap: 2rem;
 }
 
-.scroll {
-  overflow-y: auto;
-}
-
 @media screen and (max-width: 1024px) {
   .infoContainer {
     flex-direction: column-reverse;


### PR DESCRIPTION
### Description

<!-- Provide a clear and concise description of what this PR does -->

Fixes an overflow bug in the `ReviewStep` component causing the "Guest | Moderator" switch to be hidden on mobile screens.

### Type of Change

<!-- Please keep the relevant option and delete the rest. -->

- **Bug fix** (non-breaking change which fixes an issue)

### Changes Made

<!-- List the specific changes made in this PR -->

- Removed `scroll` class from `ReviewStep` css module

### Screenshots/Videos

Before|After
---|---
<img width="534" height="533" alt="image" src="https://github.com/user-attachments/assets/be321285-3569-45ef-8abc-d608a491be0a" />|<img width="537" height="584" alt="image" src="https://github.com/user-attachments/assets/709de483-14f5-4301-bc49-92b9b99e1006" />

<!-- If applicable, add screenshots or videos to demonstrate the changes -->
<!-- Before and after screenshots are especially helpful for UI changes -->

### Checklist

<!-- Check all that apply -->

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities
