### PR TITLE
UI polish

### DIFF
--- a/apps/website/src/app/[locale]/(sidebar)/events/[id]/UploadImage.module.css
+++ b/apps/website/src/app/[locale]/(sidebar)/events/[id]/UploadImage.module.css
@@ -40,7 +40,7 @@
   justify-content: space-between;
   width: 100%;
   margin: 1rem 0;
-  padding: 0 1rem;
+  padding: 0;
 
   .sectionTitle {
     margin: 0;
@@ -48,12 +48,24 @@
   }
 }
 
-@media (width >= 768px) {
+@media (width > 768px) {
   .actionCardContainer {
     display: none;
   }
+}
 
-  .sectionTitleRow {
-    padding: 0 1rem;
+@media (width < 768px) {
+  /* Button's .button:not([data-variant="icon"]) selector has specificity (0,2,0),
+     outranking this class (0,1,0). !important is needed until Button lowers its
+     own specificity (e.g. via :where()) to make overrides work naturally. */
+  .slideshowButton {
+    height: 2.4rem !important;
+    padding-inline: 0.75rem 0.3rem !important;
+    gap: 0.1rem !important;
+    font-size: var(--font-size-small) !important;
+  }
+
+  .sectionTitle[data-size] {
+    font-size: var(--font-size-heading-medium);
   }
 }

--- a/apps/website/src/app/[locale]/join/[code]/nickname.module.css
+++ b/apps/website/src/app/[locale]/join/[code]/nickname.module.css
@@ -11,7 +11,7 @@
 }
 .card {
   min-width: 0;
-  width: 100%;
+  max-width: 30rem;
 }
 
 .navigation {

--- a/apps/website/src/app/[locale]/join/[code]/page.tsx
+++ b/apps/website/src/app/[locale]/join/[code]/page.tsx
@@ -51,8 +51,9 @@ export default function Page() {
           <Title
             data-testid="title"
             align="center"
-            size="large"
+            size="medium"
             as="h1"
+            lines={3}
             description={tNickname("description")}
           >
             {eventName ? `${tNickname("title")} ${eventName}` : tNickname("title")}

--- a/packages/ui/src/components/Sidebar/Sidebar.module.css
+++ b/packages/ui/src/components/Sidebar/Sidebar.module.css
@@ -183,7 +183,7 @@
 
   &[data-color] {
     background-color: var(--color-base);
-    color: var(--color-text-contrast);
+    color: white;
 
     &:hover {
       background-color: var(--color-light);

--- a/packages/ui/src/components/Sidebar/Sidebar.module.css
+++ b/packages/ui/src/components/Sidebar/Sidebar.module.css
@@ -199,12 +199,18 @@
     font-weight: 500;
     opacity: 1;
     overflow: hidden;
-    white-space: nowrap;
 
     width: 100%;
     display: flex;
     justify-content: space-between;
     align-items: center;
+  }
+
+  .itemTitleText {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   [data-open="false"] & {

--- a/packages/ui/src/components/Sidebar/SidebarItem.tsx
+++ b/packages/ui/src/components/Sidebar/SidebarItem.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes } from "react";
+import React, { HTMLAttributes } from "react";
 import styles from "./Sidebar.module.css";
 
 export interface SidebarItemProps extends HTMLAttributes<HTMLButtonElement> {
@@ -34,7 +34,17 @@ export const SidebarItem = ({
       {...rest}
     >
       {icon}
-      {<span className={styles.itemTitle}>{children}</span>}
+      {
+        <span className={styles.itemTitle}>
+          {React.Children.map(children, child =>
+            typeof child === "string" ? (
+              <span className={styles.itemTitleText}>{child}</span>
+            ) : (
+              child
+            )
+          )}
+        </span>
+      }
     </button>
   );
 };

--- a/packages/ui/src/components/Title/Title.module.css
+++ b/packages/ui/src/components/Title/Title.module.css
@@ -122,3 +122,11 @@
   text-overflow: ellipsis;
   min-width: 0;
 }
+
+.textClamp {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}

--- a/packages/ui/src/components/Title/Title.tsx
+++ b/packages/ui/src/components/Title/Title.tsx
@@ -33,6 +33,10 @@ export interface TitleProps extends React.HTMLAttributes<HTMLHeadingElement> {
    */
   "data-color"?: ColorName;
   /**
+   * Clamp title text to this many lines, then ellipsis. Omit for single-line truncation.
+   */
+  lines?: number;
+  /**
    * Ref to the heading element
    */
   ref?: React.Ref<HTMLHeadingElement>;
@@ -50,6 +54,7 @@ export const Title = ({
   size = "large",
   weight = "bold",
   align = "left",
+  lines,
   "data-color": color,
   ref,
   className,
@@ -66,7 +71,14 @@ export const Title = ({
         className={cl(styles.title, className)}
         {...props}
       >
-        {children && <span className={styles.text}>{children}</span>}
+        {children && (
+          <span
+            className={lines ? styles.textClamp : styles.text}
+            style={lines ? { WebkitLineClamp: lines } : undefined}
+          >
+            {children}
+          </span>
+        )}
       </Component>
       {description && (
         <p data-align={align} data-size={size} className={styles.description}>


### PR DESCRIPTION
### Description
This PR polishes UI in upload and join event pages. The PR also fixes minor bug in sidebar.
<!-- Provide a clear and concise description of what this PR does -->

### Type of Change

<!-- Please keep the relevant option and delete the rest. -->

- **Bug fix** (non-breaking change which fixes an issue)
- **Other (UX/UI improvement)**:


### How Has This Been Tested?
This has been tested on IOS Safari, windows with chrome and Firefox browsers.

### Screenshots/Videos
<!-- If applicable, add screenshots or videos to demonstrate the changes -->
<!-- Before and after screenshots are especially helpful for UI changes -->
In the join event page the "Welcome to ..." text would never actually display the event name on mobile since there was little space. Now it allows for the text to wrap maximum 3 lines before truncating.
|Before |After |
|---|---|
| <img width="320" alt="JoinEventPage" src="https://github.com/user-attachments/assets/cdb553d7-048e-41aa-bacf-da2a8714b0fa" /> | <img width="289" height="621" alt="image" src="https://github.com/user-attachments/assets/559a463e-66c9-4d2d-85d5-7e32b6bc75b2" /> |
 
 In the main page the "All Photos" title were a bit too large so on mobile devices it always truncated. The slideshow button on mobile was also a bit too large and the padding on the sides of the button was awkward. 
 |Before |After |
|---|---|
| <img width="292" height="623" alt="Upload page before" src="https://github.com/user-attachments/assets/7b5fa49f-0569-4858-8212-afb3274ada75" />| <img width="291" height="623" alt="Upload page after" src="https://github.com/user-attachments/assets/be06f129-15b7-400f-a076-f58ac07d94d6" /> |

When an event had a long title the remembered events in the sidebar would not display the "moderate" page or the ">" icon because the text would not truncate to accommodate this.
 |Before |After |
|---|---|
| <img width="290" height="611" alt="Long event name in sidebar before" src="https://github.com/user-attachments/assets/6044bb58-9dd8-4594-bb97-a605f4bf339a" /> | <img width="290" height="620" alt="Long event name in sidebar after" src="https://github.com/user-attachments/assets/35e13c14-802c-44cc-a173-00cb31ccc5c4" /> |

Made the "Back" button text in the sidebar always white regardless of theme. However this implementation is not good since it hardcodes the color white. This is however also done in the Button component and we need a better solution for this, perhaps a white color text token that is theme invariant.
 |Before |After |
|---|---|
| <img width="253" height="584" alt="image" src="https://github.com/user-attachments/assets/db7c318f-f3fe-44f5-985b-0bec37badd5a" /> | <img width="255" height="586" alt="image" src="https://github.com/user-attachments/assets/1eaf2700-9a0f-4ac7-9034-a743e07ee2a4" /> |



### Checklist

<!-- Check all that apply -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have checked my code for security vulnerabilities

### NOTE
The white back button implementation in sidebar is not good since it hardcodes the color white. This is however also done in the Button component and we need a better solution for this, perhaps a white color text token that is theme invariant.